### PR TITLE
Add configuration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ fritzbox_tools:
   homeassistant_ip: "192.168.178.42"  # Optional. Needed if you want to control port forwardings for the device running Home Assistant
   profile_on: "Standard"  # Optional. Needed if you want to switch between device profiles ("Zugangsprofile")
   profile_off: "Gesperrt"  # Optional. Needed if you want to switch between device profiles ("Zugangsprofile")
-  device_list: # Optional. If you don't want to expose a profile switch for just some of your network devices
+  devices: # Optional. If you don't want to expose a profile switch for just some of your network devices
     - "Helens-iPhone"
     - "Aarons-MacBook-Air"
     - "..."

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -26,7 +26,6 @@ CONF_HOMEASSISTANT_IP = 'homeassistant_ip'
 DEFAULT_PROFILE_OFF = 'Gesperrt'
 DEFAULT_HOST = '192.168.178.1'  # set to fritzbox default
 DEFAULT_PORT = 49000            # set to fritzbox default
-DEFAULT_USERNAME = ''           # set to fritzbox default?!
 DEFAULT_PROFILE_ON = None
 DEFAULT_DEVICES = None
 DEFAULT_HOMEASSISTANT_IP = None
@@ -48,7 +47,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Optional(CONF_HOST): cv.string,
                 vol.Optional(CONF_PORT): cv.port,
-                vol.Optional(CONF_USERNAME): cv.string,  # Does it work with empty username? else set Required
+                vol.Required(CONF_USERNAME): cv.string, 
                 vol.Required(CONF_PASSWORD): cv.string,
                 vol.Optional(CONF_HOMEASSISTANT_IP): cv.string,
                 vol.Optional(CONF_DEVICES): vol.All(cv.ensure_list, [cv.string]),
@@ -65,7 +64,7 @@ async def async_setup(hass, config):
     _LOGGER.debug('Setting up fritzbox_tools component')
     host = config[DOMAIN].get(CONF_HOST, DEFAULT_HOST)
     port = config[DOMAIN].get(CONF_PORT, DEFAULT_PORT)
-    username = config[DOMAIN].get(CONF_USERNAME, DEFAULT_USERNAME)
+    username = config[DOMAIN].get(CONF_USERNAME)
     password = config[DOMAIN].get(CONF_PASSWORD)
     ha_ip = config[DOMAIN].get(CONF_HOMEASSISTANT_IP, DEFAULT_HOMEASSISTANT_IP)
     profile_off = config[DOMAIN].get(CONF_PROFILE_OFF, DEFAULT_PROFILE_OFF)

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -105,7 +105,7 @@ class FritzBoxTools(object):
             user=username,
             password=password
         )
-        self.profile_switch = FritzProfileSwitch("http://"+host, username, password)
+        self.profile_switch = FritzProfileSwitch('http://'+host, username, password)
         self.fritzstatus = fc.FritzStatus(fc=self.connection)
         self.ha_ip = ha_ip
         self.profile_on = profile_on

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -1,4 +1,6 @@
+"""Support for AVM Fritz!Box functions"""
 import logging
+
 import time
 from homeassistant.helpers import discovery
 

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -24,9 +24,9 @@ CONF_PROFILE_OFF = 'profile_off'
 CONF_HOMEASSISTANT_IP = 'homeassistant_ip'
 
 DEFAULT_PROFILE_OFF = 'Gesperrt'
-DEFAULT_HOST = '192.168.178.1' #set to fritzbox default
-DEFAULT_PORT = 49000 #set to fritzbox default
-DEFAULT_USERNAME = '' #set to fritzbox default?!
+DEFAULT_HOST = '192.168.178.1'  # set to fritzbox default
+DEFAULT_PORT = 49000            # set to fritzbox default
+DEFAULT_USERNAME = ''           # set to fritzbox default?!
 DEFAULT_PROFILE_ON = None
 DEFAULT_DEVICES = None
 DEFAULT_HOMEASSISTANT_IP = None
@@ -48,7 +48,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Optional(CONF_HOST): cv.string,
                 vol.Optional(CONF_PORT): cv.port,
-                vol.Optional(CONF_USERNAME): cv.string, # Does it work with empty username? else set Required
+                vol.Optional(CONF_USERNAME): cv.string,  # Does it work with empty username? else set Required
                 vol.Required(CONF_PASSWORD): cv.string,
                 vol.Optional(CONF_HOMEASSISTANT_IP): cv.string,
                 vol.Optional(CONF_DEVICES): vol.All(cv.ensure_list, [cv.string]),
@@ -87,7 +87,6 @@ async def async_setup(hass, config):
 
     hass.services.async_register(DOMAIN, SERVICE_RECONNECT, fritz_tools.service_reconnect_fritzbox)
 
-
     # Load the other platforms like switch
     for domain in SUPPORTED_DOMAINS:
         await discovery.async_load_platform(hass, domain, DOMAIN, {}, config)
@@ -110,7 +109,7 @@ class FritzBoxTools(object):
 
         if profile_on is not None:
             self.profile_switch = FritzProfileSwitch('http://'+host, username, password)
-            
+
         self.fritzstatus = fc.FritzStatus(fc=self.connection)
         self.ha_ip = ha_ip
         self.profile_on = profile_on

--- a/custom_components/fritzbox_tools/sensor.py
+++ b/custom_components/fritzbox_tools/sensor.py
@@ -1,3 +1,4 @@
+"""AVM Fritz!Box connectivitiy sensor"""
 import logging
 from datetime import timedelta
 from collections import defaultdict

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -89,7 +89,7 @@ class FritzBoxPortSwitch(SwitchDevice):
 
         description = port_mapping['NewPortMappingDescription']
         self._name = f'Port forward {description}'
-        id = f'fritzbox_portforward_{slugify(description}'
+        id = f'fritzbox_portforward_{slugify(description)}'
         self.entity_id = ENTITY_ID_FORMAT.format(id)
 
         self._attributes = defaultdict(str)

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -1,3 +1,4 @@
+"""Switches for AVM Fritz!Box functions"""
 import logging
 from typing import List  # noqa
 from datetime import timedelta

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -204,7 +204,7 @@ class FritzBoxProfileSwitch(SwitchDevice):
                 self.id_on = self.profiles[i]['id']
         try:
             self.id_off, self.id_on
-        except:
+        except NameError:
             _LOGGER.error('profile_on or profile_off does not match any profiles in your fritzbox')
 
         name = self.device['name']

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -64,7 +64,6 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
             errs = ', '.join(duplicated_hostnames)
             _LOGGER.error(f'You have multiple devices with the hostname {errs} in your network. '
                           'There will be no profile switches created for these.')
-            )
 
         # add device switches
         for device in devices:

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -87,8 +87,9 @@ class FritzBoxPortSwitch(SwitchDevice):
         self.connection_type = connection_type
         self.port_mapping: dict = port_mapping  # dict in the format as it comes from fritzconnection. eg: {'NewRemoteHost': '0.0.0.0', 'NewExternalPort': 22, 'NewProtocol': 'TCP', 'NewInternalPort': 22, 'NewInternalClient': '192.168.178.31', 'NewEnabled': '0', 'NewPortMappingDescription': 'Beast SSH ', 'NewLeaseDuration': 0}  # noqa
 
-        self._name = f'Port forward {port_mapping['NewPortMappingDescription']}'
-        id = f'fritzbox_portforward_{slugify(port_mapping['NewPortMappingDescription']}'
+        description = port_mapping['NewPortMappingDescription']
+        self._name = f'Port forward {description}'
+        id = f'fritzbox_portforward_{slugify(description}'
         self.entity_id = ENTITY_ID_FORMAT.format(id)
 
         self._attributes = defaultdict(str)
@@ -206,8 +207,9 @@ class FritzBoxProfileSwitch(SwitchDevice):
         except:
             _LOGGER.error('profile_on or profile_off does not match any profiles in your fritzbox')
 
-        self._name = f'Device Profile {self.device['name']}'
-        id = f'fritzbox_profile_{self.device['name']}'
+        name = self.device['name']
+        self._name = f'Device Profile {name}'
+        id = f'fritzbox_profile_{name}'
         self.entity_id = ENTITY_ID_FORMAT.format(slugify(id))
 
         if self.device['profile'] == self.id_off:

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -60,8 +60,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         hostname_count = Counter([device['name'] for device in devices])
         duplicated_hostnames = [name for name, occurence in hostname_count.items() if occurence > 1]
         if len(duplicated_hostnames) > 0:
-            _LOGGER.error('You have multiple devices with the hostname {} in your network. '
-                          'There will be no profile switches created for these.'.format(', '.join(duplicated_hostnames))
+            errs = ', '.join(duplicated_hostnames)
+            _LOGGER.error(f'You have multiple devices with the hostname {errs} in your network. '
+                          'There will be no profile switches created for these.')
             )
 
         # add device switches
@@ -86,12 +87,8 @@ class FritzBoxPortSwitch(SwitchDevice):
         self.connection_type = connection_type
         self.port_mapping: dict = port_mapping  # dict in the format as it comes from fritzconnection. eg: {'NewRemoteHost': '0.0.0.0', 'NewExternalPort': 22, 'NewProtocol': 'TCP', 'NewInternalPort': 22, 'NewInternalClient': '192.168.178.31', 'NewEnabled': '0', 'NewPortMappingDescription': 'Beast SSH ', 'NewLeaseDuration': 0}  # noqa
 
-        self._name = "Port forward {}".format(
-            port_mapping["NewPortMappingDescription"]
-        )
-        id = "fritzbox_portforward_{}".format(
-            slugify(port_mapping["NewPortMappingDescription"])
-        )
+        self._name = f'Port forward {port_mapping['NewPortMappingDescription']}'
+        id = f'fritzbox_portforward_{slugify(port_mapping['NewPortMappingDescription']}'
         self.entity_id = ENTITY_ID_FORMAT.format(id)
 
         self._attributes = defaultdict(str)
@@ -205,13 +202,13 @@ class FritzBoxProfileSwitch(SwitchDevice):
         try:
             self.id_off, self.id_on
         except:
-            _LOGGER.error("profile_on or profile_off does not match any profiles in your fritzbox")
+            _LOGGER.error('profile_on or profile_off does not match any profiles in your fritzbox')
 
-        self._name = "Device Profile {}".format(self.device["name"])
-        id = "fritzbox_profile_{}".format(self.device["name"])
+        self._name = f'Device Profile {self.device['name']}'
+        id = f'fritzbox_profile_{self.device['name']}'
         self.entity_id = ENTITY_ID_FORMAT.format(slugify(id))
 
-        if self.device["profile"] == self.id_off:
+        if self.device['profile'] == self.id_off:
             self._is_on = False
         else:
             self._is_on = True  # TODO: Decide on default behaviour
@@ -252,9 +249,9 @@ class FritzBoxProfileSwitch(SwitchDevice):
             try:
                 devices = self.fritzbox_tools.profile_switch.get_devices()
                 for device in devices:
-                    self.device = device if device["name"] == self.device["name"] else self.device
+                    self.device = device if device['name'] == self.device['name'] else self.device
                 self.profiles = self.fritzbox_tools.profile_switch.get_profiles()
-                if self.device["profile"] == self.id_off:
+                if self.device['profile'] == self.id_off:
                     self._is_on = False
                 else:
                     self._is_on = True  # TODO: Decide on default behaviour
@@ -270,7 +267,7 @@ class FritzBoxProfileSwitch(SwitchDevice):
             self._last_toggle_timestamp = time.time()
         else:
             self._is_on = False
-            _LOGGER.error("An error occurred while turning on fritzbox_tools Guest wifi switch.")
+            _LOGGER.error('An error occurred while turning on fritzbox_tools Guest wifi switch.')
 
     def turn_off(self, **kwargs) -> None:
         success: bool = self._handle_profile_switch_on_off(turn_on=False)
@@ -279,7 +276,7 @@ class FritzBoxProfileSwitch(SwitchDevice):
             self._last_toggle_timestamp = time.time()
         else:
             self._is_on = True
-            _LOGGER.error("An error occurred while turning off fritzbox_tools Guest wifi switch.")
+            _LOGGER.error('An error occurred while turning off fritzbox_tools Guest wifi switch.')
 
     def _handle_profile_switch_on_off(self, turn_on: bool) -> bool:
         # pylint: disable=import-error
@@ -297,11 +294,11 @@ class FritzBoxProfileSwitch(SwitchDevice):
 
 
 class FritzBoxGuestWifiSwitch(SwitchDevice):
-    """Defines a fritzbox_tools Home switch."""
+    """Defines a fritzbox_tools Guest Wifi switch."""
 
     name = 'FRITZ!Box Guest Wifi'
     icon = 'mdi:wifi'
-    entity_id = ENTITY_ID_FORMAT.format("fritzbox_guestwifi")
+    entity_id = ENTITY_ID_FORMAT.format('fritzbox_guestwifi')
     _update_grace_period = 5  # seconds
 
     def __init__(self, fritzbox_tools):

--- a/info.md
+++ b/info.md
@@ -11,8 +11,8 @@ This custom component allows you to get more out of your FRITZ!Box
 - Reconnect your FRITZ!Box / get new IP from provider
 - Sensor for internet connectivity (with external IP and uptime attributes)
 
+![image](https://user-images.githubusercontent.com/3121306/67151935-01451480-f2ce-11e9-8f32-473b412935c9.png)
 
-![image](https://user-images.githubusercontent.com/3121306/64920971-d42cb000-d7bd-11e9-8bdf-a21c7ea93c58.png)
 
 **Configuration (minimal):**
 


### PR DESCRIPTION
One step towards ha-fritzbox-tools as a standard component.
`device_list` is replaced by `devices`, as supplied by homeassistant.const.

Works with my setup.

One question remains for me:
Is username an optional parameter? Do the apis work with no username?

Edit - Todo towards correct styles:
- [x] change formating strings
```
# New
f"{some_value} {some_other_value}"
# Old, wrong
"{} {}".format('New', 'style')
"%s %s" % ('Old', 'style')
```
- [x] replace header by meaningful names
- [x] decide on username as optional/required

All requirements:
https://developers.home-assistant.io/docs/en/development_guidelines.html
https://developers.home-assistant.io/docs/en/creating_component_code_review.html

