### PR TITLE
fix issue #52

### DIFF
--- a/custom_components/fritzbox_tools/.translations/de.json
+++ b/custom_components/fritzbox_tools/.translations/de.json
@@ -4,9 +4,8 @@
         "step": {
             "setup_additional": {
                 "title": "Setup Fritz!Box Tools - optional settings",
-                "description": "Port forwardings need IP address of homeassistant device.\n Device profiles need a list of devices.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                "description": "Device profiles need a list of devices.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
                 "data": {
-                    "homeassistant_ip": "Port forwardings: IP of homeassistant device",
                     "profile_on": "Device profiles: Profile on",
                     "profile_off": "Device profiles: Profile off",
                     "devices": "Device profiles: comma seperated list of devices"

--- a/custom_components/fritzbox_tools/.translations/en.json
+++ b/custom_components/fritzbox_tools/.translations/en.json
@@ -4,9 +4,8 @@
         "step": {
             "setup_additional": {
                 "title": "Setup Fritz!Box Tools - optional settings",
-                "description": "Port forwardings need IP address of homeassistant device.\n Device profiles need a list of devices.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                "description": "Device profiles need a list of devices.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
                 "data": {
-                    "homeassistant_ip": "Port forwardings: IP of homeassistant device",
                     "profile_on": "Device profiles: Profile on",
                     "profile_off": "Device profiles: Profile off",
                     "devices": "Device profiles: comma seperated list of devices"

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -16,13 +16,12 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.util import get_local_ip
 
 from .const import (
-    CONF_HOMEASSISTANT_IP,
     CONF_PROFILE_OFF,
     CONF_PROFILE_ON,
     DEFAULT_DEVICES,
-    DEFAULT_HOMEASSISTANT_IP,
     DEFAULT_HOST,
     DEFAULT_PORT,
     DEFAULT_PROFILE_OFF,
@@ -46,7 +45,6 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_PORT): cv.port,
                 vol.Required(CONF_USERNAME): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(CONF_HOMEASSISTANT_IP): cv.string,
                 vol.Optional(CONF_DEVICES): vol.All(cv.ensure_list, [cv.string]),
                 vol.Optional(CONF_PROFILE_ON): cv.string,
                 vol.Optional(CONF_PROFILE_OFF): cv.string,
@@ -78,7 +76,6 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     port = entry.data.get(CONF_PORT, DEFAULT_PORT)
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
-    ha_ip = entry.data.get(CONF_HOMEASSISTANT_IP, DEFAULT_HOMEASSISTANT_IP)
     profile_off = entry.data.get(CONF_PROFILE_OFF, DEFAULT_PROFILE_OFF)
     profile_on = entry.data.get(CONF_PROFILE_ON, DEFAULT_PROFILE_ON)
     device_list = entry.data.get(CONF_DEVICES, DEFAULT_DEVICES)
@@ -88,7 +85,6 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         port=port,
         username=username,
         password=password,
-        ha_ip=ha_ip,
         profile_on=profile_on,
         profile_off=profile_off,
         device_list=device_list,
@@ -128,7 +124,6 @@ class FritzBoxTools(object):
         port,
         username,
         password,
-        ha_ip,
         profile_on,
         profile_off,
         device_list,
@@ -147,7 +142,7 @@ class FritzBoxTools(object):
             )
 
         self.fritzstatus = fc.FritzStatus(fc=self.connection)
-        self.ha_ip = ha_ip
+        self.ha_ip = get_local_ip()
         self.profile_on = profile_on
         self.profile_off = profile_off
         self.profile_last_updated = time.time()

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -7,7 +7,6 @@ from .const import (
     DOMAIN,
     CONF_PROFILE_ON,
     CONF_PROFILE_OFF,
-    CONF_HOMEASSISTANT_IP,
     DEFAULT_DEVICES,
     DEFAULT_HOST,
     DEFAULT_PORT,
@@ -52,7 +51,6 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                     vol.Optional(CONF_PORT, default=DEFAULT_PORT): vol.Coerce(int),
                     vol.Required(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,
-                    vol.Optional(CONF_HOMEASSISTANT_IP): str,
                     vol.Optional(CONF_PROFILE_ON, default=DEFAULT_PROFILE_ON): str,
                     vol.Optional(CONF_PROFILE_OFF, default=DEFAULT_PROFILE_OFF): str,
                     vol.Optional(CONF_DEVICES): str,
@@ -88,7 +86,6 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             profile_on=None,
             profile_off=None,
             device_list=devices,
-            ha_ip=None,
         )
         success, error = await fritz_tools.is_ok()
 
@@ -105,7 +102,6 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 CONF_PROFILE_ON: user_input.get(CONF_PROFILE_ON),
                 CONF_PROFILE_OFF: user_input.get(CONF_PROFILE_OFF),
                 CONF_USERNAME: username,
-                CONF_HOMEASSISTANT_IP: user_input.get(CONF_HOMEASSISTANT_IP),
                 CONF_DEVICES: devices,
             },
         )

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -94,7 +94,6 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 port=port,
                 username=username,
                 password=password,
-                ha_ip=None,
                 profile_on=None,
                 profile_off=None,
                 device_list=None
@@ -121,7 +120,6 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 CONF_PROFILE_ON: user_input.get(CONF_PROFILE_ON),
                 CONF_PROFILE_OFF: user_input.get(CONF_PROFILE_OFF),
                 CONF_USERNAME: self.fritz_tools.username,
-                CONF_HOMEASSISTANT_IP: user_input.get(CONF_HOMEASSISTANT_IP),
                 CONF_DEVICES: devices
             },
         )

--- a/custom_components/fritzbox_tools/const.py
+++ b/custom_components/fritzbox_tools/const.py
@@ -5,7 +5,6 @@ SUPPORTED_DOMAINS = ["switch", "binary_sensor"]
 
 CONF_PROFILE_ON = "profile_on"
 CONF_PROFILE_OFF = "profile_off"
-CONF_HOMEASSISTANT_IP = "homeassistant_ip"
 
 DEFAULT_HOST = "192.168.178.1"  # set to fritzbox default
 DEFAULT_PORT = 49000  # set to fritzbox default
@@ -14,7 +13,5 @@ DEFAULT_USERNAME = ""  # set to fritzbox default?!
 DEFAULT_PROFILE_ON = "Standard"
 DEFAULT_PROFILE_OFF = "Gesperrt"
 DEFAULT_DEVICES = []
-
-DEFAULT_HOMEASSISTANT_IP = None
 
 SERVICE_RECONNECT = "reconnect"

--- a/custom_components/fritzbox_tools/strings.json
+++ b/custom_components/fritzbox_tools/strings.json
@@ -2,16 +2,15 @@
     "config": {
         "title": "Fritz!Box Tools",
         "step": {
-            "setup_additional": {
-                "title": "Setup Fritz!Box Tools - optional settings",
-                "description": "Port forwardings need IP address of homeassistant device.\n Device profiles need a list of devices.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
-                "data": {
-                    "homeassistant_ip": "Port forwardings: IP of homeassistant device",
-                    "profile_on": "Device profiles: Profile on",
-                    "profile_off": "Device profiles: Profile off",
-                    "devices": "Device profiles: comma seperated list of devices"
-                }
-              },
+          "setup_additional": {
+              "title": "Setup Fritz!Box Tools - optional settings",
+              "description": "Device profiles need a list of devices.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+              "data": {
+                  "profile_on": "Device profiles: Profile on",
+                  "profile_off": "Device profiles: Profile off",
+                  "devices": "Device profiles: comma seperated list of devices"
+              }
+            },
               "start_config": {
                 "title": "Setup Fritz!Box Tools - mandatory",
                 "description": "Setup Fritz!Box Tools to control your Fritz!Box.\nMinimum needed: username, password.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -25,7 +25,7 @@ async def async_setup_entry(
     fritzbox_tools = hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE]
 
     def _create_port_switches():
-        if fritzbox_tools.ha_ip is not None:
+        if fritzbox_tools.ha_ip != "127.0.0.1":
             try:
                 _LOGGER.debug("Setting up port forward switches")
                 connection_type = fritzbox_tools.connection.call_action(


### PR DESCRIPTION
removed all the config about the homeassistant_ip.
IP is set now via `get_local_ip()`

This should work if you don't have docker network isolation. This is taken from the homekit guide:

> Docker Network Isolation
> 
> The advertise_ip option can be used to run this integration even inside an ephemeral Docker container with network isolation enabled, e.g., not using the host network.
> 
> To use advertise_ip, add the option to your homekit config:
> 
> homekit:
>   advertise_ip: "STATIC_IP_OF_YOUR_DOCKER_HOST"
> YAMLCopy
> Restart your Home Assistant instance. This feature requires running an mDNS forwarder on your Docker host, e.g., avahi-daemon in reflector mode. This kind of setup most likely requires safe_mode during the bridge setup.

Therefore another way would be to keep homeassistant_ip (just like homekit does). In that case I would suggest to keep it only in case of configuration.yaml (to make the config flow as simple as possible). However, as Hassio and venv works without such an advertise_ip I would suggest to keep it as simple as in this PR.