### PR TITLE
Adding support to control main wifi as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Custom component for Home Assistant to control your FRITZ!Box
 
 - Switch between device profiles ("Zugangsprofile") for devices in your network
 - Manage port forwardings for your Home Assistant device
+- Turn on/off wifi
 - Turn on/off guest wifi
 - Reconnect your FRITZ!Box / get new IP from provider
 - Sensor for internet connectivity (with external IP and uptime attributes)
@@ -50,7 +51,7 @@ fritzbox_tools:
 
 #### Prepare your FRITZ!Box
 
-If you want to be able to control settings of the FRITZ!Box (eg. toggle device profiles, guest wifi, port forwards, ...), you need to enable two settings in the FRITZ!Box UI `Home > Network > Network Settings (Tab)` as seen in the following screenshot:
+If you want to be able to control settings of the FRITZ!Box (eg. toggle device profiles, (guest) wifi, port forwards, ...), you need to enable two settings in the FRITZ!Box UI `Home > Network > Network Settings (Tab)` as seen in the following screenshot:
 
 ![network-settings](https://user-images.githubusercontent.com/3121306/68996105-e5fe0280-0895-11ea-8b0d-1a4487ee6838.png)
 
@@ -84,7 +85,8 @@ Note: **due to the underlying library, the update routine is not the fastest. Th
 ## Exposed entities
 
 - `service.reconnect`  Reconnect to your ISP
-- `switch.fritzbox_guest_wifi`  Turns on/off guest wifi
+- `switch.fritzbox_wifi`  Turns on/off wifi
+- `switch.fritzbox_guestwifi`  Turns on/off guest wifi
 - `binary_sensor.fritzbox_connectivity`  online/offline depending on your internet connection
 - `switch.fritzbox_portforward_[description of your forward]` for each of your port forwards for your HA device
 - `switch.fritzbox_profile_[name of your device]` for each device in your fritzbox network
@@ -122,7 +124,7 @@ automation:
   - alias: "Guests Wifi Turned On -> Send Password To Phone
     trigger:
       platform: state
-      entity_id: switch.fritzbox_guest_wifi
+      entity_id: switch.fritzbox_guestwifi
       to: 'on'
     action:
       - service: notify.pushbullet_max

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Note: **due to the underlying library, the update routine is not the fastest. Th
 
 - `service.reconnect`  Reconnect to your ISP
 - `switch.fritzbox_wifi`  Turns on/off wifi
-- `switch.fritzbox_guestwifi`  Turns on/off guest wifi
+- `switch.fritzbox_wifi_5ghz`  Turns on/off wifi (5GHz)
+- `switch.fritzbox_guest_wifi`  Turns on/off guest wifi
 - `binary_sensor.fritzbox_connectivity`  online/offline depending on your internet connection
 - `switch.fritzbox_portforward_[description of your forward]` for each of your port forwards for your HA device
 - `switch.fritzbox_profile_[name of your device]` for each device in your fritzbox network
@@ -124,7 +125,7 @@ automation:
   - alias: "Guests Wifi Turned On -> Send Password To Phone
     trigger:
       platform: state
-      entity_id: switch.fritzbox_guestwifi
+      entity_id: switch.fritzbox_guest_wifi
       to: 'on'
     action:
       - service: notify.pushbullet_max

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -87,6 +87,7 @@ async def async_setup_entry(
                             [FritzBoxProfileSwitch(fritzbox_tools, device)],
                         )
 
+    async_add_entities([FritzBoxWifiSwitch(fritzbox_tools)])
     async_add_entities([FritzBoxGuestWifiSwitch(fritzbox_tools)])
     hass.async_add_executor_job(_create_port_switches)
     hass.async_add_executor_job(_create_profile_switches)
@@ -492,6 +493,133 @@ class FritzBoxGuestWifiSwitch(SwitchDevice):
             self.fritzbox_tools.connection.call_action(
                 f"WLANConfiguration:{self.network}", "SetEnable", NewEnable=new_state
             )
+        except AuthorizationError:
+            _LOGGER.error(
+                "Authorization Error: Please check the provided credentials and verify that you can log into "
+                "the web interface.",
+                exc_info=True,
+            )
+        except (ServiceError, ActionError):
+            _LOGGER.error(
+                "Home Assistant cannot call the wished service on the FRITZ!Box.",
+                exc_info=True,
+            )
+            return False
+        else:
+            return True
+
+class FritzBoxWifiSwitch(SwitchDevice):
+    """Defines a FRITZ!Box Tools Wifi switch."""
+
+    name = "FRITZ!Box Wifi"
+    icon = "mdi:wifi"
+    entity_id = ENTITY_ID_FORMAT.format("fritzbox_wifi")
+    _update_grace_period = 5  # seconds
+
+    def __init__(self, fritzbox_tools):
+        self.fritzbox_tools = fritzbox_tools
+        self._is_on = False
+        self._last_toggle_timestamp = None
+        self._is_available = (
+            True  # set to False if an error happend during toggling the switch
+        )
+        if "WLANConfiguration:3" not in self.fritzbox_tools.connection.services:
+            self.network = 1  # no dualband wifi
+        else:
+            self.network = 2 # handle dualband wifi
+
+        super().__init__()
+
+    @property
+    def unique_id(self):
+        return f"{self.fritzbox_tools.unique_id}-{self.entity_id}"
+
+    @property
+    def device_info(self):
+        return self.fritzbox_tools.device_info
+
+    @property
+    def is_on(self) -> bool:
+        return self._is_on
+
+    @property
+    def available(self) -> bool:
+        return self._is_available
+
+    async def _async_fetch_update(self):
+        from fritzconnection.fritzconnection import AuthorizationError
+
+        try:
+            status = self.fritzbox_tools.connection.call_action(
+                "WLANConfiguration:1", "GetInfo"
+            )["NewStatus"]
+            self._is_on = True if status == "Up" else False
+            self._is_available = True
+        except AuthorizationError:
+            _LOGGER.error(
+                "Authorization Error: Please check the provided credentials and verify that you can log "
+                "into the web interface.",
+                exc_info=True,
+            )
+            self._is_available = False
+        except Exception:
+            _LOGGER.error("Could not get Wifi state", exc_info=True)
+            self._is_available = False
+
+    async def async_update(self):
+        if (
+            self._last_toggle_timestamp is not None
+            and time.time() < self._last_toggle_timestamp + self._update_grace_period
+        ):
+            # We skip update for 5 seconds after toggling the switch
+            # This is because the router needs some time to change the wifi state
+            _LOGGER.debug(
+                "Not updating switch state, because last toggle happend < 5 seconds ago"
+            )
+        else:
+            _LOGGER.debug("Updating wifi switch state...")
+            # Update state from device
+            await self._async_fetch_update()
+
+    async def async_turn_on(self, **kwargs) -> None:
+        success: bool = await self._async_handle_wifi_turn_on_off(turn_on=True)
+        if success is True:
+            self._is_on = True
+            self._last_toggle_timestamp = time.time()
+        else:
+            self._is_on = False
+            _LOGGER.error(
+                "An error occurred while turning on fritzbox_tools wifi switch."
+            )
+
+    async def async_turn_off(self, **kwargs) -> None:
+        success: bool = await self._async_handle_wifi_turn_on_off(turn_on=False)
+        if success is True:
+            self._is_on = False
+            self._last_toggle_timestamp = time.time()
+        else:
+            self._is_on = True
+            _LOGGER.error(
+                "An error occurred while turning off fritzbox_tools wifi switch."
+            )
+
+    async def _async_handle_wifi_turn_on_off(self, turn_on: bool) -> bool:
+        # pylint: disable=import-error
+        from fritzconnection.fritzconnection import (
+            ServiceError,
+            ActionError,
+            AuthorizationError,
+        )
+
+        new_state = "1" if turn_on else "0"
+        try:
+            self.fritzbox_tools.connection.call_action(
+                "WLANConfiguration:1", "SetEnable", NewEnable=new_state
+            )
+            if self.network == 2:
+                self.fritzbox_tools.connection.call_action(
+                    "WLANConfiguration:2", "SetEnable", NewEnable=new_state
+                )
         except AuthorizationError:
             _LOGGER.error(
                 "Authorization Error: Please check the provided credentials and verify that you can log into "


### PR DESCRIPTION
I like to turn off my wifi during the night. So I copied and modified your guest wifi code so that another switch is now available to turn on/off the primary wifi.

**Breaking Change:**
`switch.fritzbox_guestwifi` -> `switch.fritzbox_guest_wifi`