### PR TITLE
Fix the docs link

### DIFF
--- a/info.md
+++ b/info.md
@@ -24,7 +24,7 @@ Check out the [README](https://github.com/mammuth/ha-fritzbox-tools/blob/master/
 #### Prepare your FRITZ!Box
 
 If you want to be able to control settings of the FRITZ!Box (eg. toggle device profiles, guest wifi, port forwards, ...), you need to performe some settings on your FRITZ!Box.
-Please refer to the [documentation](https://github.com/mammuth/ha-fritzbox-tools/blob/master/README.md#configuration) for more details.
+Please refer to the [documentation](https://github.com/mammuth/ha-fritzbox-tools/#configuration) for more details.
 
 
 


### PR DESCRIPTION
The docs link is going to the raw file, so I just changed that.
Thanks for the great tool
Keep the improvements coming as they are much appreciated.

It doesn't look like they are pointing to the raw file in the code, but they must just be redirected there.