### PR TITLE
Use async tasks for sync function calls to fritzconnection 

### DIFF
--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -194,12 +194,12 @@ class FritzBoxTools(object):
         ]
         self._device_info = self._fetch_device_info()
 
-    async def async_update_profiles(self):
+    async def async_update_profiles(self, hass):
         if time.time() > self.profile_last_updated + 5:
             # do not update profiles too often (takes too long...)!
-            await asyncio.coroutine(self.profile_switch.fetch_profiles)()
-            await asyncio.coroutine(self.profile_switch.fetch_devices)()
-            await asyncio.coroutine(self.profile_switch.fetch_device_profiles)()
+            await hass.async_add_executor_job(self.profile_switch.fetch_profiles)
+            await hass.async_add_executor_job(self.profile_switch.fetch_devices)
+            await hass.async_add_executor_job(self.profile_switch.fetch_device_profiles)
             self.profile_last_updated = time.time()
 
     def service_reconnect_fritzbox(self, call) -> None:

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -206,7 +206,7 @@ class FritzBoxTools(object):
         _LOGGER.info("Reconnecting the fritzbox.")
         self.connection.reconnect()
 
-    async def is_ok(self):
+    def is_ok(self):
         # TODO for future: do more of the async_setup_entry checks right here
 
         from fritzconnection.core.exceptions import FritzConnectionException

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -139,6 +139,10 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigType) -> bool
 
 
 class FritzBoxTools(object):
+    """
+    Attention: The initialization of the class performs sync I/O. If you're calling this from within Home Assistant,
+    wrap it in await self.hass.async_add_executor_job(lambda: FritzBoxTools(...))
+    """
     def __init__(
         self,
         password,

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -97,7 +97,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     use_port = entry.data.get(CONF_USE_PORT, DEFAULT_USE_PORT)
     use_deflections = entry.data.get(CONF_USE_DEFLECTIONS, DEFAULT_USE_DEFLECTIONS)
 
-    fritz_tools = FritzBoxTools(
+    fritz_tools = await hass.async_add_executor_job(lambda: FritzBoxTools(
         host=host,
         port=port,
         username=username,
@@ -105,11 +105,11 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         profile_on=profile_on,
         profile_off=profile_off,
         device_list=device_list,
-        use_wifi = use_wifi,
-        use_deflections = use_deflections,
-        use_port = use_port,
-        use_devices = use_devices,
-    )
+        use_wifi=use_wifi,
+        use_deflections=use_deflections,
+        use_port=use_port,
+        use_devices=use_devices,
+    ))
 
     hass.data.setdefault(DOMAIN, {})[DATA_FRITZ_TOOLS_INSTANCE] = fritz_tools
 
@@ -185,6 +185,11 @@ class FritzBoxTools(object):
         self.use_deflections = use_deflections
         self.use_devices = use_devices
 
+        self._unique_id = self.connection.call_action("DeviceInfo:1", "GetInfo")[
+            "NewSerialNumber"
+        ]
+        self._device_info = self._fetch_device_info()
+
     async def async_update_profiles(self):
         if time.time() > self.profile_last_updated + 5:
             # do not update profiles too often (takes too long...)!
@@ -212,13 +217,13 @@ class FritzBoxTools(object):
 
     @property
     def unique_id(self):
-        serial = self.connection.call_action("DeviceInfo:1", "GetInfo")[
-            "NewSerialNumber"
-        ]
-        return serial
+        return self._unique_id
 
     @property
     def device_info(self):
+        return self._device_info
+
+    def _fetch_device_info(self):
         info = self.connection.call_action("DeviceInfo:1", "GetInfo")
         return {
             "identifiers": {

--- a/custom_components/fritzbox_tools/binary_sensor.py
+++ b/custom_components/fritzbox_tools/binary_sensor.py
@@ -3,7 +3,7 @@ import logging
 from collections import defaultdict
 from datetime import timedelta
 
-from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorEntity
+from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -24,7 +24,7 @@ async def async_setup_entry(
     return True
 
 
-class FritzBoxConnectivitySensor(BinarySensorEntity):
+class FritzBoxConnectivitySensor(BinarySensorDevice):
     name = "FRITZ!Box Connectivity"
     entity_id = ENTITY_ID_FORMAT.format("fritzbox_connectivity")
     icon = "mdi:router-wireless"

--- a/custom_components/fritzbox_tools/binary_sensor.py
+++ b/custom_components/fritzbox_tools/binary_sensor.py
@@ -3,7 +3,7 @@ import logging
 from collections import defaultdict
 from datetime import timedelta
 
-from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorDevice
+from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -24,7 +24,7 @@ async def async_setup_entry(
     return True
 
 
-class FritzBoxConnectivitySensor(BinarySensorDevice):
+class FritzBoxConnectivitySensor(BinarySensorEntity):
     name = "FRITZ!Box Connectivity"
     entity_id = ENTITY_ID_FORMAT.format("fritzbox_connectivity")
     icon = "mdi:router-wireless"
@@ -63,7 +63,7 @@ class FritzBoxConnectivitySensor(BinarySensorDevice):
         self._is_on = True
         try:
             status = self.fritzbox_tools.fritzstatus
-            self._is_on = status.is_connected
+            self._is_on = await self.hass.async_add_executor_job(lambda: status.is_connected)
             self._is_available = True
             for attr in [
                 "modelname",
@@ -72,7 +72,7 @@ class FritzBoxConnectivitySensor(BinarySensorDevice):
                 "uptime",
                 "str_uptime",
             ]:
-                self._attributes[attr] = getattr(status, attr)
+                self._attributes[attr] = await self.hass.async_add_executor_job(lambda: getattr(status, attr))
         except Exception:
             _LOGGER.error("Error getting the state from the FRITZ!Box", exc_info=True)
             self._is_available = False

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -113,7 +113,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             username = user_input.get(CONF_USERNAME)
             password = user_input.get(CONF_PASSWORD)
 
-            self.fritz_tools = FritzBoxTools(
+            self.fritz_tools = await self.hass.async_add_executor_job(lambda: FritzBoxTools(
                 host=host,
                 port=port,
                 username=username,
@@ -121,7 +121,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 profile_on=None,
                 profile_off=None,
                 device_list=[]
-            )
+            ))
             success, error = await self.fritz_tools.is_ok()
 
             if not success:
@@ -204,7 +204,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         if isinstance(devices, str):
             devices = devices.replace(" ", "").split(",")
 
-        fritz_tools = FritzBoxTools(
+        fritz_tools = await self.hass.async_add_executor_job(lambda: FritzBoxTools(
             host=host,
             port=port,
             username=username,
@@ -212,7 +212,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             profile_on=None,
             profile_off=None,
             device_list=[],
-        )
+        ))
         success, error = await fritz_tools.is_ok()
 
         if not success:

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -122,7 +122,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 profile_off=None,
                 device_list=[]
             ))
-            success, error = await self.fritz_tools.is_ok()
+            success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
 
             if not success:
                 errors["base"] = error
@@ -213,7 +213,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             profile_off=None,
             device_list=[],
         ))
-        success, error = await fritz_tools.is_ok()
+        success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
 
         if not success:
             _LOGGER.error('Import of config failed. Check your fritzbox credentials',error)

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -510,7 +510,7 @@ class FritzBoxProfileSwitch(SwitchDevice):
         return self._is_available
 
     async def _async_fetch_update(self):
-        await self.fritzbox_tools.async_update_profiles()
+        await self.hass.async_add_executor_job(self.fritzbox_tools.async_update_profiles)
         try:
             devices = self.fritzbox_tools.profile_switch.get_devices()
             for device in devices:
@@ -573,7 +573,7 @@ class FritzBoxProfileSwitch(SwitchDevice):
         else:
             state = [[self.device["id1"], self.id_off]]
         try:
-            self.fritzbox_tools.profile_switch.set_profiles(state)
+            await self.hass.async_add_executor_job(lambda: self.fritzbox_tools.profile_switch.set_profiles(state))
         except Exception:
             _LOGGER.error(
                 f"Home Assistant cannot call the wished service on the FRITZ!Box.",

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -207,11 +207,11 @@ class FritzBoxPortSwitch(SwitchDevice):
         from fritzconnection.core.exceptions import FritzConnectionException
 
         try:
-            self.port_mapping = self.fritzbox_tools.connection.call_action(
+            self.port_mapping = await self.hass.async_add_executor_job(lambda: self.fritzbox_tools.connection.call_action(
                 self.connection_type,
                 "GetGenericPortMappingEntry",
                 NewPortMappingIndex=self._idx,
-            )
+            ))
             _LOGGER.debug(self.port_mapping)
             self._is_on = self.port_mapping["NewEnabled"] is True
             self._is_available = True
@@ -276,9 +276,9 @@ class FritzBoxPortSwitch(SwitchDevice):
 
         self.port_mapping["NewEnabled"] = "1" if turn_on else "0"
         try:
-            self.fritzbox_tools.connection.call_action(
+            self.hass.async_add_executor_job(lambda: self.fritzbox_tools.connection.call_action(
                 self.connection_type, "AddPortMapping", **self.port_mapping
-            )
+            ))
         except FritzSecurityError:
             _LOGGER.error(
                 "Authorization Error: Please check the provided credentials and verify that you can log into "

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -294,6 +294,7 @@ class FritzBoxPortSwitch(SwitchDevice):
         else:
             return True
 
+
 class FritzBoxDeflectionSwitch(SwitchDevice):
     """Defines a FRITZ!Box Tools PortForward switch."""
 
@@ -345,8 +346,11 @@ class FritzBoxDeflectionSwitch(SwitchDevice):
         from fritzconnection.core.exceptions import FritzConnectionException
 
         try:
+            resp = await self.hass.async_add_executor_job(
+                lambda: self.fritzbox_tools.connection.call_action("X_AVM-DE_OnTel:1", "GetDeflections")
+            )
             self.dict_of_deflection = xmltodict.parse(
-                self.fritzbox_tools.connection.call_action("X_AVM-DE_OnTel:1", "GetDeflections")["NewDeflectionList"]
+                resp["NewDeflectionList"]
             )["List"]["Item"]
             if isinstance(self.dict_of_deflection, list):
                 self.dict_of_deflection = self.dict_of_deflection[self.id]
@@ -417,9 +421,9 @@ class FritzBoxDeflectionSwitch(SwitchDevice):
 
         new_state = '1' if turn_on else '0'
         try:
-            self.fritzbox_tools.connection.call_action(
+            self.hass.async_add_executor_job(lambda: self.fritzbox_tools.connection.call_action(
                 "X_AVM-DE_OnTel:1","SetDeflectionEnable", NewDeflectionId=self.id, NewEnable=new_state
-            )
+            ))
         except FritzSecurityError:
             _LOGGER.error(
                 "Authorization Error: Please check the provided credentials and verify that you can log into "
@@ -579,6 +583,7 @@ class FritzBoxProfileSwitch(SwitchDevice):
         else:
             return True
 
+
 class FritzBoxWifiSwitch(SwitchDevice):
     """Defines a FRITZ!Box Tools Wifi switch."""
 
@@ -622,9 +627,9 @@ class FritzBoxWifiSwitch(SwitchDevice):
         from fritzconnection.core.exceptions import FritzConnectionException
 
         try:
-            wifi_info = self._fritzbox_tools.connection.call_action(
+            wifi_info = await self.hass.async_add_executor_job(lambda: self._fritzbox_tools.connection.call_action(
                 f"WLANConfiguration:{self._network_num}", "GetInfo"
-            )
+            ))
             _LOGGER.debug("Guest WiFi GetInfo:")
             _LOGGER.debug(wifi_info)
             self._is_on = True if wifi_info["NewStatus"] == "Up" else False
@@ -682,9 +687,9 @@ class FritzBoxWifiSwitch(SwitchDevice):
         from fritzconnection.core.exceptions import FritzSecurityError, FritzConnectionException
 
         try:
-            self._fritzbox_tools.connection.call_action(
+            self.hass.async_add_executor_job(lambda: self._fritzbox_tools.connection.call_action(
                 f"WLANConfiguration{self._network_num}", "SetEnable", NewEnable="1" if turn_on else "0"
-            )
+            ))
         except FritzSecurityError:
             _LOGGER.error(
                 "Authorization Error: Please check the provided credentials and verify that you can log into "

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -510,7 +510,7 @@ class FritzBoxProfileSwitch(SwitchDevice):
         return self._is_available
 
     async def _async_fetch_update(self):
-        await self.hass.async_add_executor_job(self.fritzbox_tools.async_update_profiles)
+        await self.fritzbox_tools.async_update_profiles(self.hass)
         try:
             devices = self.fritzbox_tools.profile_switch.get_devices()
             for device in devices:


### PR DESCRIPTION
Kind of a hassle to work with a sync library, but it looks like that will also improve the overall performance of the integration! 🎉 

I tested manually:
- [x] Connectivity sensor meta data
- [x] Get/Set port switch
- [x] Get/Set 2.4 Ghz wifi
- [x] Get/Set guest wifi switch
- [x] Get/Set call deflections
- [ ] Yaml Mode

Closes #82 