### PR TITLE
Rename entity class names to reduce warnings

### DIFF
--- a/custom_components/fritzbox_tools/binary_sensor.py
+++ b/custom_components/fritzbox_tools/binary_sensor.py
@@ -3,7 +3,7 @@ import logging
 from collections import defaultdict
 from datetime import timedelta
 
-from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorDevice
+from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -24,7 +24,7 @@ async def async_setup_entry(
     return True
 
 
-class FritzBoxConnectivitySensor(BinarySensorDevice):
+class FritzBoxConnectivitySensor(BinarySensorEntity):
     name = "FRITZ!Box Connectivity"
     entity_id = ENTITY_ID_FORMAT.format("fritzbox_connectivity")
     icon = "mdi:router-wireless"

--- a/custom_components/fritzbox_tools/binary_sensor.py
+++ b/custom_components/fritzbox_tools/binary_sensor.py
@@ -3,7 +3,11 @@ import logging
 from collections import defaultdict
 from datetime import timedelta
 
-from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorEntity
+try:
+    from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorEntity
+except ImportError:
+    from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorDevice as BinarySensorEntity
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -7,7 +7,7 @@ import xmltodict
 
 from collections import Counter, defaultdict
 
-from homeassistant.components.switch import SwitchDevice, ENTITY_ID_FORMAT
+from homeassistant.components.switch import SwitchEntity, ENTITY_ID_FORMAT
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.util import slugify
@@ -153,7 +153,7 @@ async def async_setup_entry(
     return True
 
 
-class FritzBoxPortSwitch(SwitchDevice):
+class FritzBoxPortSwitch(SwitchEntity):
     """Defines a FRITZ!Box Tools PortForward switch."""
 
     icon = "mdi:lan"
@@ -295,7 +295,7 @@ class FritzBoxPortSwitch(SwitchDevice):
             return True
 
 
-class FritzBoxDeflectionSwitch(SwitchDevice):
+class FritzBoxDeflectionSwitch(SwitchEntity):
     """Defines a FRITZ!Box Tools PortForward switch."""
 
     icon = "mdi:phone-forward"
@@ -440,7 +440,7 @@ class FritzBoxDeflectionSwitch(SwitchDevice):
             return True
 
 
-class FritzBoxProfileSwitch(SwitchDevice):
+class FritzBoxProfileSwitch(SwitchEntity):
     """Defines a FRITZ!Box Tools DeviceProfile switch."""
 
     # Note: Update routine is very slow. SCAN_INTERVAL should be set to higher values!
@@ -584,7 +584,7 @@ class FritzBoxProfileSwitch(SwitchDevice):
             return True
 
 
-class FritzBoxWifiSwitch(SwitchDevice):
+class FritzBoxWifiSwitch(SwitchEntity):
     """Defines a FRITZ!Box Tools Wifi switch."""
 
     icon = "mdi:wifi"

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -7,7 +7,11 @@ import xmltodict
 
 from collections import Counter, defaultdict
 
-from homeassistant.components.switch import SwitchEntity, ENTITY_ID_FORMAT
+try:
+    from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity
+except ImportError:
+    from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchDevice as SwitchEntity
+
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.util import slugify


### PR DESCRIPTION
Change entity class names to reduce warnings with HA Version 0.110

This is my first pull request. Hopefully I did everything right :)


I tested (as appropriate):
- [ ] Get/Set port switch
- [X] Get/Set 2.4 Ghz wifi
- [X] Get/Set 5 Ghz wifi
- [X] Get/Set guest wifi switch
- [ ] Get/Set call deflections
- [X] Connectivity sensor
- [ ] Yaml Mode

Closes issue #87