### PR TITLE
toggle profile switches instead of individual devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,10 @@ fritzbox_tools:
   host: "192.168.178.1"  # required
   username: "home-assistant"  # required (create one at `System > FRITZ!Box Benutzer` on your router)
   password: "yourfritzboxpassword"  # required
-  devices: # Optional. Needed if you want to control the profiles of your network devices.
-    - "Helens-iPhone"
-    - "Aarons-MacBook-Air"
+  profiles: # Optional. Needed if you want to control the profiles of your network devices.
+    - "Helen"
+    - "Aaron"
     - "..."
-  profile_on: "Standard"  # Optional. Use if the names of your "Zugangsprofile" are different as the defaults.
-  profile_off: "Gesperrt"  # Optional.
   use_wifi: True # Optional, default True: if False no wifi switches will be exposed
   use_port: True  # Optional, default True: if False no port switches will be exposed
   use_devices: True  # Optional, default True: if False no device switches will be exposed, redundant if devices is not specified
@@ -76,16 +74,15 @@ Note: **Currently only port forwards for the device which is running HA are supp
 
 ### Device profiles**
 
-You can switch between two device profiles ("Zugangsprofile") within Home Assistant for the devices within your network.
+You can switch the online time of device profiles ("Zugangsprofile") within Home Assistant.
 
 Requirements:
-- Add the (FRITZ!Box) names of the devices you want to control to `device_list`.
-- Optionally set `profile_on` and `profile_off` to the names of your profiles (default: "Standard" and "Gesperrt") in the configuration of `fritzbox_tools`
+- In the FRITZ!Box: Create profiles and assign devices to those profiles.
+- Add the (FRITZ!Box) names of the profiles you want to control to `profile_list`.
 
-The device profiles will be exposed as switches in your HA installation (search for `fritzbox_profile` in your entity page to find the IDs). If the switch is toggled on, the profile you specified in `profile_on` is activated, if the switch is off, `profile_off` is activated.
+The device profiles will be exposed as switches in your HA installation (search for `fritzbox_profile` in your entity page to find the IDs). 
 
-Note: **due to the underlying library, the update routine is not the fastest. This might result in warnings.**
-
+If the switch is toggled on, the devices assigned to the specific profile have internet access. If the switch is toggled off, the devices can not access the internet.
 
 #### Exposed entities
 
@@ -96,7 +93,7 @@ Note: **due to the underlying library, the update routine is not the fastest. Th
 - `switch.fritzbox_guest_wifi`  Turns on/off guest wifi
 - `binary_sensor.fritzbox_connectivity`  online/offline depending on your internet connection
 - `switch.fritzbox_portforward_[description of your forward]` for each of your port forwards for your HA device
-- `switch.fritzbox_profile_[name of your device]` for each device in your fritzbox network
+- `switch.fritzbox_profile_[name of your profile]` for each profile you have set
 
 
 ## Example Automations and Scripts

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Custom component for Home Assistant to control your FRITZ!Box
 
 **Features:**
 
-- Switch between device profiles ("Zugangsprofile") for devices in your network
+- Switch between access profiles ("Zugangsprofile") for devices in your network
 - Turn on/off call deflections ("Rufumleitung")
 - Manage port forwardings for your Home Assistant device
 - Turn on/off wifi and guest wifi
@@ -41,18 +41,18 @@ fritzbox_tools:
   username: "home-assistant"  # required (create one at `System > FRITZ!Box Benutzer` on your router)
   password: "yourfritzboxpassword"  # required
   profiles: # Optional. Needed if you want to control the profiles of your network devices.
-    - "Helen"
-    - "Aaron"
-    - "..."
+    - "Gesperrt"
+    - "Gast"
+    - "Kinder Smartphones"
   use_wifi: True # Optional, default True: if False no wifi switches will be exposed
   use_port: True  # Optional, default True: if False no port switches will be exposed
-  use_devices: True  # Optional, default True: if False no device switches will be exposed, redundant if devices is not specified
+  use_profiles: True  # Optional, default True: if False no device switches will be exposed, redundant if devices is not specified
   use_deflections: True # Optional, default True: if False no call deflection switches will be exposed
 ```
 
 ### Prepare your FRITZ!Box
 
-If you want to be able to control settings of the FRITZ!Box (eg. toggle device profiles, (guest) wifi, port forwards, ...), you need to enable two settings in the FRITZ!Box UI `Home > Network > Network Settings (Tab)` as seen in the following screenshot:
+If you want to be able to control settings of the FRITZ!Box (eg. toggle access profiles, (guest) wifi, port forwards, ...), you need to enable two settings in the FRITZ!Box UI `Home > Network > Network Settings (Tab)` as seen in the following screenshot:
 
 ![network-settings](https://user-images.githubusercontent.com/3121306/68996105-e5fe0280-0895-11ea-8b0d-1a4487ee6838.png)
 Note that the option is only visible if you turn on the "advanced view" on your FRITZ!Box.
@@ -72,15 +72,15 @@ Note: **Currently only port forwards for the device which is running HA are supp
 
 ![port_forwardings](https://user-images.githubusercontent.com/3121306/72677989-264e4c80-3aa2-11ea-9d56-7be3d025897b.png)
 
-### Device profiles**
+### Access profiles**
 
-You can switch the online time of device profiles ("Zugangsprofile") within Home Assistant.
+You can switch the online time of access profiles ("Zugangsprofile") within Home Assistant.
 
 Requirements:
 - In the FRITZ!Box: Create profiles and assign devices to those profiles.
 - Add the (FRITZ!Box) names of the profiles you want to control to `profile_list`.
 
-The device profiles will be exposed as switches in your HA installation (search for `fritzbox_profile` in your entity page to find the IDs). 
+The access profiles will be exposed as switches in your HA installation (search for `fritzbox_profile` in your entity page to find the IDs). 
 
 If the switch is toggled on, the devices assigned to the specific profile have internet access. If the switch is toggled off, the devices can not access the internet.
 

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -176,12 +176,15 @@ class FritzBoxTools(object):
             self._device_info = self._fetch_device_info()
             self.success = True
             self.error = False
-        except PermissionError:
-            self.success = False
-            self.error = "connection_error_profiles"
         except FritzConnectionException:
             self.success = False
             self.error = "connection_error"
+        except PermissionError:
+            self.success = False
+            self.error = "connection_error_profiles"
+        except AttributeError:
+            self.success = False
+            self.error = "profile_not_found"
             
             
         self.ha_ip = get_local_ip()    

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -27,12 +27,12 @@ from .const import (
     SERVICE_REBOOT,
     SUPPORTED_DOMAINS,
     CONF_USE_WIFI,
-    CONF_USE_DEVICES,
+    CONF_USE_PROFILES,
     CONF_USE_DEFLECTIONS,
     CONF_USE_PORT,
     CONF_PROFILES,
     DEFAULT_USE_WIFI,
-    DEFAULT_USE_DEVICES,
+    DEFAULT_USE_PROFILES,
     DEFAULT_USE_DEFLECTIONS,
     DEFAULT_USE_PORT,
 )
@@ -52,7 +52,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(CONF_USERNAME): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
                 vol.Optional(CONF_PROFILES): vol.All(cv.ensure_list, [cv.string]),
-                vol.Optional(CONF_USE_DEVICES): cv.string,
+                vol.Optional(CONF_USE_PROFILES): cv.string,
                 vol.Optional(CONF_USE_PORT): cv.string,
                 vol.Optional(CONF_USE_WIFI): cv.string,
                 vol.Optional(CONF_USE_DEFLECTIONS): cv.string,
@@ -85,7 +85,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
     profile_list = entry.data.get(CONF_PROFILES, DEFAULT_PROFILES)
-    use_devices = entry.data.get(CONF_USE_DEVICES, DEFAULT_USE_DEVICES)
+    use_profiles = entry.data.get(CONF_USE_PROFILES, DEFAULT_USE_PROFILES)
     use_wifi = entry.data.get(CONF_USE_WIFI, DEFAULT_USE_WIFI)
     use_port = entry.data.get(CONF_USE_PORT, DEFAULT_USE_PORT)
     use_deflections = entry.data.get(CONF_USE_DEFLECTIONS, DEFAULT_USE_DEFLECTIONS)
@@ -99,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         use_wifi=use_wifi,
         use_deflections=use_deflections,
         use_port=use_port,
-        use_devices=use_devices,
+        use_profiles=use_profiles,
     ))
 
     hass.data.setdefault(DOMAIN, {})[DATA_FRITZ_TOOLS_INSTANCE] = fritz_tools
@@ -148,7 +148,7 @@ class FritzBoxTools(object):
         use_port = DEFAULT_USE_PORT,
         use_deflections = DEFAULT_USE_DEFLECTIONS,
         use_wifi = DEFAULT_USE_WIFI,
-        use_devices = DEFAULT_USE_DEVICES,
+        use_profiles = DEFAULT_USE_PROFILES,
     ):
         # pylint: disable=import-error
         from fritzconnection import FritzConnection
@@ -160,7 +160,7 @@ class FritzBoxTools(object):
         
         try:
             self.connection = FritzConnection(
-                address=host, port=port, user=username, password=password, timeout=30.0
+                address=host, port=port, user=username, password=password, timeout=60.0
             )
             if profile_list != DEFAULT_PROFILES:
                 self.profile_switch = {profile: FritzProfileSwitch(
@@ -198,7 +198,7 @@ class FritzBoxTools(object):
         self.use_wifi = use_wifi
         self.use_port = use_port
         self.use_deflections = use_deflections
-        self.use_devices = use_devices
+        self.use_profiles = use_profiles
 
     def service_reconnect_fritzbox(self, call) -> None:
         _LOGGER.info("Reconnecting the fritzbox.")

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -164,6 +164,8 @@ class FritzBoxTools(object):
             self.profile_switch = {profile: FritzProfileSwitch(
                 "http://" + host, username, password, profile
             ) for profile in profile_list}
+        else:
+            self.profile_switch={}
 
         self.fritzstatus = FritzStatus(fc=self.connection)
         self.ha_ip = get_local_ip()

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -5,18 +5,15 @@ import voluptuous as vol
 from homeassistant import config_entries
 from .const import (
     DOMAIN,
-    CONF_PROFILE_ON,
-    CONF_PROFILE_OFF,
     CONF_USE_DEFLECTIONS,
     CONF_USE_DEVICES,
     CONF_USE_WIFI,
     CONF_USE_PORT,
+    CONF_PROFILES,
     DEFAULT_USERNAME,
-    DEFAULT_DEVICES,
+    DEFAULT_PROFILES,
     DEFAULT_HOST,
     DEFAULT_PORT,
-    DEFAULT_PROFILE_ON,
-    DEFAULT_PROFILE_OFF,
     DEFAULT_USE_DEFLECTIONS,
     DEFAULT_USE_WIFI,
     DEFAULT_USE_DEVICES,
@@ -29,7 +26,6 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
     CONF_PORT,
-    CONF_DEVICES,
 )
 
 from . import FritzBoxTools, CONFIG_SCHEMA
@@ -72,9 +68,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             step_id="setup_devices",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(CONF_PROFILE_ON, default=DEFAULT_PROFILE_ON): str,
-                    vol.Optional(CONF_PROFILE_OFF, default=DEFAULT_PROFILE_OFF): str,
-                    vol.Optional(CONF_DEVICES): str,
+                    vol.Optional(CONF_PROFILES): str,
                 }
             ),
             errors=errors or {},
@@ -118,9 +112,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 port=port,
                 username=username,
                 password=password,
-                profile_on=None,
-                profile_off=None,
-                device_list=[]
+                profile_list=[]
             ))
             success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
 
@@ -140,17 +132,15 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             errors = {}
             return await self._show_setup_form_devices(errors)
         else:
-            devices = []
+            profiles = []
             return self.async_create_entry(
                 title="FRITZ!Box Tools",
                 data={
                     CONF_HOST: self.fritz_tools.host,
                     CONF_PASSWORD: self.fritz_tools.password,
                     CONF_PORT: self.fritz_tools.port,
-                    CONF_PROFILE_ON: DEFAULT_PROFILE_ON,
-                    CONF_PROFILE_ON: DEFAULT_PROFILE_OFF,
                     CONF_USERNAME: self.fritz_tools.username,
-                    CONF_DEVICES: devices,
+                    CONF_PROFILES: profiles,
                     CONF_USE_WIFI: self._use_wifi,
                     CONF_USE_DEFLECTIONS: self._use_deflections,
                     CONF_USE_PORT: self._use_port,
@@ -160,9 +150,9 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
 
 
     async def async_step_setup_devices(self, user_input=None):
-        devices = user_input.get(CONF_DEVICES,DEFAULT_DEVICES)
-        if isinstance(devices, str):
-            devices = devices.replace(' ', '').split(',')
+        profiles = user_input.get(CONF_PROFILES,DEFAULT_PROFILES)
+        if isinstance(profiles, str):
+            profiles = profiles.replace(' ', '').split(',')
 
         return self.async_create_entry(
             title="FRITZ!Box Tools",
@@ -170,10 +160,8 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 CONF_HOST: self.fritz_tools.host,
                 CONF_PASSWORD: self.fritz_tools.password,
                 CONF_PORT: self.fritz_tools.port,
-                CONF_PROFILE_ON: user_input.get(CONF_PROFILE_ON, DEFAULT_PROFILE_ON),
-                CONF_PROFILE_OFF: user_input.get(CONF_PROFILE_OFF, DEFAULT_PROFILE_OFF),
                 CONF_USERNAME: self.fritz_tools.username,
-                CONF_DEVICES: devices,
+                CONF_PROFILES: profiles,
                 CONF_USE_WIFI: self._use_wifi,
                 CONF_USE_DEFLECTIONS: self._use_deflections,
                 CONF_USE_PORT: self._use_port,
@@ -199,19 +187,17 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         port = import_config.get(CONF_PORT, DEFAULT_PORT)
         username = import_config.get(CONF_USERNAME)
         password = import_config.get(CONF_PASSWORD)
-        devices = import_config.get(CONF_DEVICES,DEFAULT_DEVICES)
+        profiles = import_config.get(CONF_PROFILES,DEFAULT_PROFILES)
 
-        if isinstance(devices, str):
-            devices = devices.replace(" ", "").split(",")
+        if isinstance(profiles, str):
+            profiles = profiles.replace(" ", "").split(",")
 
         fritz_tools = await self.hass.async_add_executor_job(lambda: FritzBoxTools(
             host=host,
             port=port,
             username=username,
             password=password,
-            profile_on=None,
-            profile_off=None,
-            device_list=[],
+            profile_list=[],
         ))
         success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
 
@@ -224,10 +210,8 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 CONF_HOST: host,
                 CONF_PASSWORD: password,
                 CONF_PORT: port,
-                CONF_PROFILE_ON: import_config.get(CONF_PROFILE_ON, DEFAULT_PROFILE_ON),
-                CONF_PROFILE_OFF: import_config.get(CONF_PROFILE_OFF, DEFAULT_PROFILE_OFF),
                 CONF_USERNAME: username,
-                CONF_DEVICES: devices,
+                CONF_PROFILES: profiles,
                 CONF_USE_WIFI: DEFAULT_USE_WIFI,
                 CONF_USE_DEFLECTIONS: DEFAULT_USE_DEFLECTIONS,
                 CONF_USE_PORT: DEFAULT_USE_PORT,

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -97,30 +97,30 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         return await self._show_setup_form_init()
 
     async def async_step_start_config(self, user_input=None):
-            if user_input is None:
-                return await self._show_setup_form_init()
+        if user_input is None:
+            return await self._show_setup_form_init()
 
-            errors = {}
+        errors = {}
 
-            host = user_input.get(CONF_HOST, DEFAULT_HOST)
-            port = user_input.get(CONF_PORT, DEFAULT_PORT)
-            username = user_input.get(CONF_USERNAME)
-            password = user_input.get(CONF_PASSWORD)
+        host = user_input.get(CONF_HOST, DEFAULT_HOST)
+        port = user_input.get(CONF_PORT, DEFAULT_PORT)
+        username = user_input.get(CONF_USERNAME)
+        password = user_input.get(CONF_PASSWORD)
 
-            self.fritz_tools = await self.hass.async_add_executor_job(lambda: FritzBoxTools(
-                host=host,
-                port=port,
-                username=username,
-                password=password,
-                profile_list=[]
-            ))
-            success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
+        self.fritz_tools = await self.hass.async_add_executor_job(lambda: FritzBoxTools(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            profile_list=[]
+        ))
+        success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
 
-            if not success:
-                errors["base"] = error
-                return await self._show_setup_form_init(errors)
+        if not success:
+            errors["base"] = error
+            return await self._show_setup_form_init(errors)
 
-            return await self._show_setup_form_options(errors)
+        return await self._show_setup_form_options(errors)
 
     async def async_step_setup_options(self, user_input=None):
         self._use_port = user_input.get(CONF_USE_PORT,DEFAULT_USE_PORT)
@@ -153,6 +153,20 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         profiles = user_input.get(CONF_PROFILES,DEFAULT_PROFILES)
         if isinstance(profiles, str):
             profiles = profiles.replace(' ', '').split(',')
+        
+        self.fritz_tools = await self.hass.async_add_executor_job(lambda: FritzBoxTools(
+            host=self.fritz_tools.host,
+            port=self.fritz_tools.port,
+            username=self.fritz_tools.username,
+            password=self.fritz_tools.password,
+            profile_list=profiles,
+        ))
+        success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
+        
+        errors = {}
+        if not success:
+            errors["base"] = error
+            return await self._show_setup_form_init(errors)
 
         return self.async_create_entry(
             title="FRITZ!Box Tools",
@@ -197,7 +211,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             port=port,
             username=username,
             password=password,
-            profile_list=[],
+            profile_list=profiles,
         ))
         success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
 

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -6,7 +6,7 @@ from homeassistant import config_entries
 from .const import (
     DOMAIN,
     CONF_USE_DEFLECTIONS,
-    CONF_USE_DEVICES,
+    CONF_USE_PROFILES,
     CONF_USE_WIFI,
     CONF_USE_PORT,
     CONF_PROFILES,
@@ -16,7 +16,7 @@ from .const import (
     DEFAULT_PORT,
     DEFAULT_USE_DEFLECTIONS,
     DEFAULT_USE_WIFI,
-    DEFAULT_USE_DEVICES,
+    DEFAULT_USE_PROFILES,
     DEFAULT_USE_PORT,
     SUPPORTED_DOMAINS,
 )
@@ -62,10 +62,10 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             errors=errors or {},
         )
 
-    async def _show_setup_form_devices(self, errors=None):
+    async def _show_setup_form_profiles(self, errors=None):
         """Show the setup form to the user."""
         return self.async_show_form(
-            step_id="setup_devices",
+            step_id="setup_profiles",
             data_schema=vol.Schema(
                 {
                     vol.Optional(CONF_PROFILES): str,
@@ -82,7 +82,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 {
                     vol.Required(CONF_USE_WIFI, default=DEFAULT_USE_WIFI): bool,
                     vol.Required(CONF_USE_PORT, default=DEFAULT_USE_PORT): bool,
-                    vol.Required(CONF_USE_DEVICES, default=DEFAULT_USE_DEVICES): bool,
+                    vol.Required(CONF_USE_PROFILES, default=DEFAULT_USE_PROFILES): bool,
                     vol.Required(CONF_USE_DEFLECTIONS, default=DEFAULT_USE_DEFLECTIONS): bool,
                 }
             ),
@@ -126,11 +126,11 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         self._use_port = user_input.get(CONF_USE_PORT,DEFAULT_USE_PORT)
         self._use_deflections = user_input.get(CONF_USE_DEFLECTIONS,DEFAULT_USE_DEFLECTIONS)
         self._use_wifi = user_input.get(CONF_USE_WIFI,DEFAULT_USE_WIFI)
-        self._use_devices = user_input.get(CONF_USE_DEVICES, DEFAULT_USE_DEVICES)
+        self._use_profiles = user_input.get(CONF_USE_PROFILES, DEFAULT_USE_PROFILES)
 
-        if self._use_devices:
+        if self._use_profiles:
             errors = {}
-            return await self._show_setup_form_devices(errors)
+            return await self._show_setup_form_profiles(errors)
         else:
             profiles = []
             return self.async_create_entry(
@@ -144,15 +144,15 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                     CONF_USE_WIFI: self._use_wifi,
                     CONF_USE_DEFLECTIONS: self._use_deflections,
                     CONF_USE_PORT: self._use_port,
-                    CONF_USE_DEVICES: self._use_devices,
+                    CONF_USE_PROFILES: self._use_profiles,
                 },
             )
 
 
-    async def async_step_setup_devices(self, user_input=None):
+    async def async_step_setup_profiles(self, user_input=None):
         profiles = user_input.get(CONF_PROFILES,DEFAULT_PROFILES)
         if isinstance(profiles, str):
-            profiles = profiles.replace(' ', '').split(',')
+            profiles = profiles.replace(', ', ',').split(',')
         
         self.fritz_tools = await self.hass.async_add_executor_job(lambda: FritzBoxTools(
             host=self.fritz_tools.host,
@@ -166,7 +166,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         errors = {}
         if not success:
             errors["base"] = error
-            return await self._show_setup_form_devices(errors)
+            return await self._show_setup_form_profiles(errors)
 
         return self.async_create_entry(
             title="FRITZ!Box Tools",
@@ -179,7 +179,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 CONF_USE_WIFI: self._use_wifi,
                 CONF_USE_DEFLECTIONS: self._use_deflections,
                 CONF_USE_PORT: self._use_port,
-                CONF_USE_DEVICES: self._use_devices,
+                CONF_USE_PROFILES: self._use_profiles,
             },
         )
 
@@ -231,6 +231,6 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 CONF_USE_WIFI: DEFAULT_USE_WIFI,
                 CONF_USE_DEFLECTIONS: DEFAULT_USE_DEFLECTIONS,
                 CONF_USE_PORT: DEFAULT_USE_PORT,
-                CONF_USE_DEVICES: DEFAULT_USE_DEVICES,
+                CONF_USE_PROFILES: DEFAULT_USE_PROFILES,
             },
         )

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -193,10 +193,11 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         This will execute for any complete
         configuration.
         """
+        _LOGGER.debug("start step import_config")
         self.import_schema = CONFIG_SCHEMA
 
         errors = {}
-
+        
         host = import_config.get(CONF_HOST, DEFAULT_HOST)
         port = import_config.get(CONF_PORT, DEFAULT_PORT)
         username = import_config.get(CONF_USERNAME)
@@ -205,6 +206,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
 
         if isinstance(profiles, str):
             profiles = profiles.replace(" ", "").split(",")
+            
 
         fritz_tools = await self.hass.async_add_executor_job(lambda: FritzBoxTools(
             host=host,
@@ -213,7 +215,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             password=password,
             profile_list=profiles,
         ))
-        success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
+        success, error = await self.hass.async_add_executor_job(fritz_tools.is_ok)
 
         if not success:
             _LOGGER.error('Import of config failed. Check your fritzbox credentials',error)

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -166,7 +166,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         errors = {}
         if not success:
             errors["base"] = error
-            return await self._show_setup_form_init(errors)
+            return await self._show_setup_form_devices(errors)
 
         return self.async_create_entry(
             title="FRITZ!Box Tools",

--- a/custom_components/fritzbox_tools/const.py
+++ b/custom_components/fritzbox_tools/const.py
@@ -8,7 +8,7 @@ CONF_PROFILES = "profiles"
 CONF_USE_WIFI = "use_wifi"
 CONF_USE_PORT = "use_port"
 CONF_USE_DEFLECTIONS = "use_deflections"
-CONF_USE_DEVICES = "use_devices"
+CONF_USE_PROFILES = "use_profiles"
 
 DEFAULT_HOST = "192.168.178.1"  # set to fritzbox default
 DEFAULT_PORT = 49000  # set to fritzbox default
@@ -17,7 +17,7 @@ DEFAULT_USERNAME = ""  # set to fritzbox default?!
 DEFAULT_USE_WIFI = True
 DEFAULT_USE_PORT = True
 DEFAULT_USE_DEFLECTIONS = True
-DEFAULT_USE_DEVICES = True
+DEFAULT_USE_PROFILES = True
 
 DEFAULT_PROFILES = []
 

--- a/custom_components/fritzbox_tools/const.py
+++ b/custom_components/fritzbox_tools/const.py
@@ -3,8 +3,7 @@
 DOMAIN = "fritzbox_tools"
 SUPPORTED_DOMAINS = ["switch", "binary_sensor"]
 
-CONF_PROFILE_ON = "profile_on"
-CONF_PROFILE_OFF = "profile_off"
+CONF_PROFILES = "profiles"
 
 CONF_USE_WIFI = "use_wifi"
 CONF_USE_PORT = "use_port"
@@ -20,9 +19,7 @@ DEFAULT_USE_PORT = True
 DEFAULT_USE_DEFLECTIONS = True
 DEFAULT_USE_DEVICES = True
 
-DEFAULT_PROFILE_ON = "Standard"
-DEFAULT_PROFILE_OFF = "Gesperrt"
-DEFAULT_DEVICES = []
+DEFAULT_PROFILES = []
 
 SERVICE_RECONNECT = "reconnect"
 SERVICE_REBOOT = "reboot"

--- a/custom_components/fritzbox_tools/manifest.json
+++ b/custom_components/fritzbox_tools/manifest.json
@@ -4,6 +4,6 @@
     "documentation": "https://github.com/mammuth/ha-fritzbox-tools/blob/master/README.md",
     "codeowners": ["@mammuth"],
     "dependencies": [],
-    "requirements": ["fritzconnection==1.2.0", "fritz-switch-profiles==1.0.0", "xmltodict==0.12.0"],
+    "requirements": ["fritzconnection==1.2.0", "fritzprofiles==0.1", "xmltodict==0.12.0"],
     "config_flow": true
   }

--- a/custom_components/fritzbox_tools/manifest.json
+++ b/custom_components/fritzbox_tools/manifest.json
@@ -4,6 +4,6 @@
     "documentation": "https://github.com/mammuth/ha-fritzbox-tools/blob/master/README.md",
     "codeowners": ["@mammuth"],
     "dependencies": [],
-    "requirements": ["fritzconnection==1.2.0", "fritzprofiles", "xmltodict==0.12.0"],
+    "requirements": ["fritzconnection==1.2.0", "fritzprofiles==0.4", "xmltodict==0.12.0"],
     "config_flow": true
   }

--- a/custom_components/fritzbox_tools/manifest.json
+++ b/custom_components/fritzbox_tools/manifest.json
@@ -4,6 +4,6 @@
     "documentation": "https://github.com/mammuth/ha-fritzbox-tools/blob/master/README.md",
     "codeowners": ["@mammuth"],
     "dependencies": [],
-    "requirements": ["fritzconnection==1.2.0", "fritzprofiles==0.1", "xmltodict==0.12.0"],
+    "requirements": ["fritzconnection==1.2.0", "fritzprofiles", "xmltodict==0.12.0"],
     "config_flow": true
   }

--- a/custom_components/fritzbox_tools/strings.json
+++ b/custom_components/fritzbox_tools/strings.json
@@ -13,12 +13,10 @@
               }
             },
             "setup_devices": {
-                "title": "Setup FRITZ!Box Tools - device settings",
-                "description": "Device profiles need a list of devices.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                "title": "Setup FRITZ!Box Tools - profile settings",
+                "description": "Device profiles needs at least one profile.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
                 "data": {
-                    "profile_on": "Device profiles: Profile on",
-                    "profile_off": "Device profiles: Profile off",
-                    "devices": "Device profiles: comma seperated list of devices"
+                    "profiles": "Device profiles: Comma seperated list of Profiles"
                 }
               },
               "start_config": {

--- a/custom_components/fritzbox_tools/strings.json
+++ b/custom_components/fritzbox_tools/strings.json
@@ -6,17 +6,17 @@
               "title": "Setup FRITZ!Box Tools - optional settings",
               "description": "Select which features you want to use.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
               "data": {
-                  "use_devices": "device profile switches",
+                  "use_profiles": "access profile switches",
                   "use_wifi": "wifi switches",
                   "use_port": "port forwarding switches for hass device",
                   "use_deflections": "call deflection switches"
               }
             },
-            "setup_devices": {
+            "setup_profiles": {
                 "title": "Setup FRITZ!Box Tools - profile settings",
-                "description": "Device profiles needs at least one profile.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                "description": "Access profiles needs at least one profile.\nCheck your profiles in the FRITZ!Box at Internet/Filters/Access Profiles\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
                 "data": {
-                    "profiles": "Device profiles: Comma seperated list of Profiles"
+                    "profiles": "Access profiles: Comma separated list of profile names"
                 }
               },
               "start_config": {
@@ -32,8 +32,8 @@
         },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
-            "connection_error_profiles": "Profile switches only work if login via user and password is enabled in the FRITZ!Box",
-            "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box"
+            "connection_error_profiles": "Profile switches only work if login with FRITZ!Box user name and password is enabled in the FRITZ!Box. This can be changed in the FRITZ!Box at System/FRITZ!Box Users/Login to the Home Network.",
+            "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box. Check your profiles in the FRITZ!Box at Internet/Filters/Access Profiles."
         },
         "abort": {
             "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",

--- a/custom_components/fritzbox_tools/strings.json
+++ b/custom_components/fritzbox_tools/strings.json
@@ -31,7 +31,8 @@
             }
         },
         "error": {
-            "connection_error": "Failed to connect to FRITZ!Box. Check your username and password."
+            "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
+            "connection_error_profiles": "Failed to connect to FRITZ!Box. Check your username and password. Profile switches only work if login via user and password is enabled in the FRITZ!Box"
         },
         "abort": {
             "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",

--- a/custom_components/fritzbox_tools/strings.json
+++ b/custom_components/fritzbox_tools/strings.json
@@ -32,7 +32,8 @@
         },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
-            "connection_error_profiles": "Failed to connect to FRITZ!Box. Check your username and password. Profile switches only work if login via user and password is enabled in the FRITZ!Box"
+            "connection_error_profiles": "Profile switches only work if login via user and password is enabled in the FRITZ!Box",
+            "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box"
         },
         "abort": {
             "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -102,32 +102,13 @@ async def async_setup_entry(
                 )
 
     def _create_profile_switches():
-        if len(fritzbox_tools.device_list) > 0:
+        if len(fritzbox_tools.profile_switch) > 0:
             _LOGGER.debug("Setting up profile switches")
-            devices = fritzbox_tools.profile_switch.get_devices()
-
-            # Identify duplicated host names and log an error message
-            hostname_count = Counter([device["name"] for device in devices])
-            duplicated_hostnames = [
-                name for name, occurence in hostname_count.items() if occurence > 1
-            ]
-            if len(duplicated_hostnames) > 0:
-                errs = ", ".join(duplicated_hostnames)
-                _LOGGER.error(
-                    f"You have multiple devices with the hostname {errs} in your network. "
-                    "There will be no profile switches created for these."
+            for profile in fritzbox_tools.profile_switch.keys():
+                hass.add_job(
+                    async_add_entities,
+                    [FritzBoxProfileSwitch(fritzbox_tools, profile)],
                 )
-
-            # add device switches
-            for device in devices:
-                # Check for duplicated host names in the devices list.
-                if device["name"] not in duplicated_hostnames:
-                    if device["name"] in fritzbox_tools.device_list:
-                        _LOGGER.debug(f"device to be added: {device}")
-                        hass.add_job(
-                            async_add_entities,
-                            [FritzBoxProfileSwitch(fritzbox_tools, device)],
-                        )
 
     def _create_wifi_switches():
         if "WLANConfiguration3" not in fritzbox_tools.connection.services:
@@ -452,44 +433,16 @@ class FritzBoxProfileSwitch(SwitchEntity):
     icon = "mdi:lan"  # TODO: search for a better one
     _update_grace_period = 30  # seconds
 
-    def __init__(self, fritzbox_tools, device):
+    def __init__(self, fritzbox_tools, profile):
         self.fritzbox_tools = fritzbox_tools
-        self.device = device
-        self.profiles = self.fritzbox_tools.profile_switch.get_profiles()
-        for i in range(len(self.profiles)):
-            if self.profiles[i]["name"] == self.fritzbox_tools.profile_off:
-                self.id_off = self.profiles[i]["id"]
-            elif self.profiles[i]["name"] == self.fritzbox_tools.profile_on:
-                self.id_on = self.profiles[i]["id"]
-        try:
-            self.id_off, self.id_on
-        except AttributeError:
-            _LOGGER.error(
-                "profile_on or profile_off does not match any profiles in your fritzbox"
-            )
+        self.profile = profile
+        self.profile_switch = self.fritzbox_tools.profile_switch[self.profile]
 
-        name = self.device["name"]
-        self._name = f"Device Profile {name}"
-        id = f"fritzbox_profile_{name}"
+        self._name = f"Device Profile {self.profile}"
+        id = f"fritzbox_profile_{self.profile}"
         self.entity_id = ENTITY_ID_FORMAT.format(slugify(id))
 
-        if self.device["profile"] == self.id_off:
-            self._is_on = False
-        else:
-            self._is_on = True  # TODO: Decide on default behaviour
-
-        self._last_toggle_timestamp = None
-        self._is_available = (
-            True  # set to False if an error happend during toggling the switch
-        )
-        if (
-            self.id_on is None or self.id_off is None
-        ):  # that's the case if wrong setting in config.
-            self._is_available = False
-            _LOGGER.error(
-                "The profile you tried to set does not exist in the fritzbox. "
-                "Please check profile_on and profile_off in your config for errors"
-            )
+        self._is_available = True  # set to False if an error happend during toggling the switch
 
         super().__init__()
 
@@ -514,19 +467,16 @@ class FritzBoxProfileSwitch(SwitchEntity):
         return self._is_available
 
     async def _async_fetch_update(self):
-        await self.fritzbox_tools.async_update_profiles(self.hass)
         try:
-            devices = self.fritzbox_tools.profile_switch.get_devices()
-            for device in devices:
-                self.device = (
-                    device if device["name"] == self.device["name"] else self.device
-                )
-            self.profiles = self.fritzbox_tools.profile_switch.get_profiles()
-            if self.device["profile"] == self.id_off:
+            status = await self.hass.async_add_executor_job(
+                lambda: self.profile_switch.get_state()
+            )
+            if status == "never":
                 self._is_on = False
-            else:
+            elif status == "unlimited":
                 self._is_on = True  # TODO: Decide on default behaviour
-            self._is_available = True
+            else:
+                self._is_available = False
         except Exception:
             _LOGGER.error(
                 f"Could not get state of profile switch", exc_info=True
@@ -534,19 +484,7 @@ class FritzBoxProfileSwitch(SwitchEntity):
             self._is_available = False
 
     async def async_update(self):
-        if (
-            self._last_toggle_timestamp is not None
-            and time.time() < self._last_toggle_timestamp + self._update_grace_period
-        ):
-            # We skip update for 5 seconds after toggling the switch
-            # This is because the router needs some time to change the guest wifi state
-            _LOGGER.debug(
-                "Not updating switch state, because last toggle happend < {} seconds ago".format(
-                    self._update_grace_period
-                )
-            )
-        else:
-            await self._async_fetch_update()
+        await self._async_fetch_update()
 
     async def async_turn_on(self, **kwargs) -> None:
         success: bool = await self._async_handle_profile_switch_on_off(turn_on=True)
@@ -573,11 +511,11 @@ class FritzBoxProfileSwitch(SwitchEntity):
     async def _async_handle_profile_switch_on_off(self, turn_on: bool) -> bool:
         # pylint: disable=import-error
         if turn_on:
-            state = [[self.device["id1"], self.id_on]]
+            state = "unlimited"
         else:
-            state = [[self.device["id1"], self.id_off]]
+            state = "never"
         try:
-            await self.hass.async_add_executor_job(lambda: self.fritzbox_tools.profile_switch.set_profiles(state))
+            await self.hass.async_add_executor_job(lambda: self.profile_switch.set_state(state))
         except Exception:
             _LOGGER.error(
                 f"Home Assistant cannot call the wished service on the FRITZ!Box.",

--- a/custom_components/fritzbox_tools/translations/de.json
+++ b/custom_components/fritzbox_tools/translations/de.json
@@ -13,12 +13,10 @@
               }
             },
             "setup_devices": {
-                "title": "Setup FRITZ!Box Tools - device settings",
-                "description": "Device profiles need a list of devices.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                "title": "Setup FRITZ!Box Tools - profile settings",
+                "description": "Device profiles needs at least one profile.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
                 "data": {
-                    "profile_on": "Device profiles: Profile on",
-                    "profile_off": "Device profiles: Profile off",
-                    "devices": "Device profiles: comma seperated list of devices"
+                    "profiles": "Device profiles: Comma seperated list of Profiles"
                 }
               },
               "start_config": {

--- a/custom_components/fritzbox_tools/translations/de.json
+++ b/custom_components/fritzbox_tools/translations/de.json
@@ -6,17 +6,17 @@
               "title": "Setup FRITZ!Box Tools - optional settings",
               "description": "Select which features you want to use.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
               "data": {
-                  "use_devices": "device profile switches",
+                  "use_profiles": "access profile switches",
                   "use_wifi": "wifi switches",
                   "use_port": "port forwarding switches for hass device",
                   "use_deflections": "call deflection switches"
               }
             },
-            "setup_devices": {
+            "setup_profiles": {
                 "title": "Setup FRITZ!Box Tools - profile settings",
-                "description": "Device profiles needs at least one profile.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                "description": "Access profiles needs at least one profile.\nCheck your profiles in the FRITZ!Box at Internet/Filters/Access Profiles\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
                 "data": {
-                    "profiles": "Device profiles: Comma seperated list of Profiles"
+                    "profiles": "Access profiles: Comma separated list of profile names"
                 }
               },
               "start_config": {
@@ -32,8 +32,8 @@
         },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
-            "connection_error_profiles": "Profile switches only work if login via user and password is enabled in the FRITZ!Box",
-            "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box"
+            "connection_error_profiles": "Profile switches only work if login with FRITZ!Box user name and password is enabled in the FRITZ!Box. This can be changed in the FRITZ!Box at System/FRITZ!Box Users/Login to the Home Network.",
+            "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box. Check your profiles in the FRITZ!Box at Internet/Filters/Access Profiles."
         },
         "abort": {
             "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",

--- a/custom_components/fritzbox_tools/translations/de.json
+++ b/custom_components/fritzbox_tools/translations/de.json
@@ -31,7 +31,8 @@
             }
         },
         "error": {
-            "connection_error": "Failed to connect to FRITZ!Box. Check your username and password."
+            "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
+            "connection_error_profiles": "Failed to connect to FRITZ!Box. Check your username and password. Profile switches only work if login via user and password is enabled in the FRITZ!Box"
         },
         "abort": {
             "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",

--- a/custom_components/fritzbox_tools/translations/de.json
+++ b/custom_components/fritzbox_tools/translations/de.json
@@ -32,7 +32,8 @@
         },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
-            "connection_error_profiles": "Failed to connect to FRITZ!Box. Check your username and password. Profile switches only work if login via user and password is enabled in the FRITZ!Box"
+            "connection_error_profiles": "Profile switches only work if login via user and password is enabled in the FRITZ!Box",
+            "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box"
         },
         "abort": {
             "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",

--- a/custom_components/fritzbox_tools/translations/en.json
+++ b/custom_components/fritzbox_tools/translations/en.json
@@ -13,12 +13,10 @@
               }
             },
             "setup_devices": {
-                "title": "Setup FRITZ!Box Tools - device settings",
-                "description": "Device profiles need a list of devices.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                "title": "Setup FRITZ!Box Tools - profile settings",
+                "description": "Device profiles needs at least one profile.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
                 "data": {
-                    "profile_on": "Device profiles: Profile on",
-                    "profile_off": "Device profiles: Profile off",
-                    "devices": "Device profiles: comma seperated list of devices"
+                    "profiles": "Device profiles: Comma seperated list of Profiles"
                 }
               },
               "start_config": {

--- a/custom_components/fritzbox_tools/translations/en.json
+++ b/custom_components/fritzbox_tools/translations/en.json
@@ -6,17 +6,17 @@
               "title": "Setup FRITZ!Box Tools - optional settings",
               "description": "Select which features you want to use.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
               "data": {
-                  "use_devices": "device profile switches",
+                  "use_profiles": "access profile switches",
                   "use_wifi": "wifi switches",
                   "use_port": "port forwarding switches for hass device",
                   "use_deflections": "call deflection switches"
               }
             },
-            "setup_devices": {
+            "setup_profiles": {
                 "title": "Setup FRITZ!Box Tools - profile settings",
-                "description": "Device profiles needs at least one profile.\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                "description": "Access profiles needs at least one profile.\nCheck your profiles in the FRITZ!Box at Internet/Filters/Access Profiles\nleave it empty if you don't need it.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
                 "data": {
-                    "profiles": "Device profiles: Comma seperated list of Profiles"
+                    "profiles": "Access profiles: Comma separated list of profile names"
                 }
               },
               "start_config": {
@@ -32,8 +32,8 @@
         },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
-            "connection_error_profiles": "Profile switches only work if login via user and password is enabled in the FRITZ!Box",
-            "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box"
+            "connection_error_profiles": "Profile switches only work if login with FRITZ!Box user name and password is enabled in the FRITZ!Box. This can be changed in the FRITZ!Box at System/FRITZ!Box Users/Login to the Home Network.",
+            "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box. Check your profiles in the FRITZ!Box at Internet/Filters/Access Profiles."
         },
         "abort": {
             "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",

--- a/custom_components/fritzbox_tools/translations/en.json
+++ b/custom_components/fritzbox_tools/translations/en.json
@@ -31,7 +31,8 @@
             }
         },
         "error": {
-            "connection_error": "Failed to connect to FRITZ!Box. Check your username and password."
+            "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
+            "connection_error_profiles": "Failed to connect to FRITZ!Box. Check your username and password. Profile switches only work if login via user and password is enabled in the FRITZ!Box"
         },
         "abort": {
             "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",

--- a/custom_components/fritzbox_tools/translations/en.json
+++ b/custom_components/fritzbox_tools/translations/en.json
@@ -32,7 +32,8 @@
         },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
-            "connection_error_profiles": "Failed to connect to FRITZ!Box. Check your username and password. Profile switches only work if login via user and password is enabled in the FRITZ!Box"
+            "connection_error_profiles": "Profile switches only work if login via user and password is enabled in the FRITZ!Box",
+            "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box"
         },
         "abort": {
             "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",

--- a/info.md
+++ b/info.md
@@ -5,7 +5,7 @@ This custom component allows you to get more out of your FRITZ!Box
 
 **Features:**
 
-- Switch internet access of device profiles ("Zugangsprofile")
+- Switch internet access of access profiles ("Zugangsprofile")
 - Turn on/off call deflections ("Rufumleitung")
 - Manage port forwardings for your Home Assistant device
 - Turn on/off wifi and guest wifi
@@ -23,7 +23,7 @@ Check out the [README](https://github.com/mammuth/ha-fritzbox-tools/blob/master/
 
 #### Prepare your FRITZ!Box
 
-If you want to be able to control settings of the FRITZ!Box (eg. toggle device profiles, guest wifi, port forwards, ...), you need to perform some settings on your FRITZ!Box.
+If you want to be able to control settings of the FRITZ!Box (eg. toggle access profiles, guest wifi, port forwards, ...), you need to perform some settings on your FRITZ!Box.
 Please refer to the [documentation](https://github.com/mammuth/ha-fritzbox-tools/#configuration) for more details.
 
 

--- a/info.md
+++ b/info.md
@@ -5,7 +5,7 @@ This custom component allows you to get more out of your FRITZ!Box
 
 **Features:**
 
-- Switch between device profiles ("Zugangsprofile") for devices in your network
+- Switch internet access of device profiles ("Zugangsprofile")
 - Turn on/off call deflections ("Rufumleitung")
 - Manage port forwardings for your Home Assistant device
 - Turn on/off wifi and guest wifi


### PR DESCRIPTION
With this PR, profiles are toggled (by changing the online time from unlimited to never and vice versa). The previous switch for device profiles reassigned devices to groups which has been a huge overkill. 

I tested (as appropriate):
- [ ] Get/Set port switch
- [ ] Get/Set 2.4 Ghz wifi
- [ ] Get/Set 5 Ghz wifi
- [ ] Get/Set guest wifi switch
- [ ] Get/Set call deflections
- [ ] Connectivity sensor
- [x] Yaml Mode

Closes issue #109 

Remaining Question:
- [x] Does a sid (session id) expire? Needs longer term test. Could easily be fixed in underlying library.
Shouldn't be a problem with release 0.2 of fritzprofiles. Could have been one of the problems of the usage of the other library.

- [x] Naming of `CONF_USE_DEVICES` and  `DEFAULT_USE_DEVICES` have been kept untouched. Should they be changed?  