### PR TITLE
bump to new version

### DIFF
--- a/custom_components/fritzbox_tools/manifest.json
+++ b/custom_components/fritzbox_tools/manifest.json
@@ -4,6 +4,6 @@
     "documentation": "https://github.com/mammuth/ha-fritzbox-tools/blob/master/README.md",
     "codeowners": ["@mammuth"],
     "dependencies": [],
-    "requirements": ["fritzconnection==1.2.0", "fritzprofiles==0.4", "xmltodict==0.12.0"],
+    "requirements": ["fritzconnection==1.2.0", "fritzprofiles==0.5", "xmltodict==0.12.0"],
     "config_flow": true
   }


### PR DESCRIPTION
This update of fritzprofiles should account for a bug that occurred when connection to fritzbox has been dropped (e.g. after a restart).

I tested (as appropriate):
- [ ] Get/Set port switch
- [ ] Get/Set 2.4 Ghz wifi
- [ ] Get/Set 5 Ghz wifi
- [ ] Get/Set guest wifi switch
- [ ] Get/Set call deflections
- [ ] Connectivity sensor
- [ ] Yaml Mode

Closes issue #xxx