### PR TITLE
bump fritzprofiles to new version

### DIFF
--- a/custom_components/fritzbox_tools/manifest.json
+++ b/custom_components/fritzbox_tools/manifest.json
@@ -4,6 +4,6 @@
     "documentation": "https://github.com/mammuth/ha-fritzbox-tools/blob/master/README.md",
     "codeowners": ["@mammuth"],
     "dependencies": [],
-    "requirements": ["fritzconnection==1.2.0", "fritzprofiles==0.5", "xmltodict==0.12.0"],
+    "requirements": ["fritzconnection==1.2.0", "fritzprofiles==0.5.2", "xmltodict==0.12.0"],
     "config_flow": true
   }


### PR DESCRIPTION
Add a proper xml parser to sid challenge in fritzprofiles. This way errors like #112 should disappear.

I tested (as appropriate):
- [ ] Get/Set port switch
- [ ] Get/Set 2.4 Ghz wifi
- [ ] Get/Set 5 Ghz wifi
- [ ] Get/Set guest wifi switch
- [ ] Get/Set call deflections
- [ ] Connectivity sensor
- [ ] Yaml Mode

Closes issue #112 