### PR TITLE
add the possibility to add multiple fritzboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The following script can be used to easily add a reconnect button to your UI. If
 fritz_box_reconnect:
   alias: "Reconnect FRITZ!Box"
   sequence:
-  - service: fritzbox_tools.reconnect
+  - service: fritzbox_tools.reconnect_[model]
 ```
 
 **Automation: Reconnect / get new IP every night**
@@ -119,7 +119,7 @@ automation:
     platform: time
     at: '05:00:00'
   action:
-    - service: fritzbox_tools.reconnect
+    - service: fritzbox_tools.reconnect_[model]
 ```
 
 **Automation: Phone notification with wifi credentials when guest wifi is created**
@@ -130,7 +130,7 @@ automation:
   - alias: "Guests Wifi Turned On -> Send Password To Phone
     trigger:
       platform: state
-      entity_id: switch.fritzbox_guest_wifi
+      entity_id: switch.fritzbox_[model]_guest_wifi
       to: 'on'
     action:
       - service: notify.pushbullet_max
@@ -159,7 +159,7 @@ automation:
       at: 05:00:00
     action:
     - service: switch.turn_on
-      entity_id: switch.fritzbox_portforward_http_server
+      entity_id: switch.fritzbox_[model]_portforward_http_server
     - service: hassio.addon_stop
       data:
         addon: core_nginx_proxy
@@ -172,7 +172,7 @@ automation:
       data:
         addon: core_nginx_proxy
     - service: switch.turn_off
-      entity_id: switch.fritzbox_portforward_http_server
+      entity_id: switch.fritzbox_[model]_portforward_http_server
 ```
 
 **Sensor: External IP address of your router**
@@ -185,8 +185,8 @@ sensors:
     sensors:
       external_ip:
         friendly_name: "External IP Address"
-        entity_id: binary_sensor.fritzbox_connectivity  # only react on changes of the router connectivity sensor
-        value_template: "{{ state_attr('binary_sensor.fritzbox_connectivity', 'external_ip') }}"
+        entity_id: binary_sensor.fritzbox_[model]_connectivity  # only react on changes of the router connectivity sensor
+        value_template: "{{ state_attr('binary_sensor.fritzbox_[model]_connectivity', 'external_ip') }}"
         icon_template: mdi:router-wireless
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ If the switch is toggled on, the devices assigned to the specific profile have i
 
 #### Exposed entities
 
-- `service.reconnect_[model]`  Reconnect to your ISP
-- `service.reboot_[model]`  Reboot your FRITZ!Box
+- `service.reconnect`  Reconnect to your ISP
+- `service.reboot`  Reboot your FRITZ!Box
 - `switch.fritzbox_[model_wifi]`  Turns on/off wifi
 - `switch.fritzbox_[model_wifi_5ghz]`  Turns on/off wifi (5GHz)
 - `switch.fritzbox_[model]_guest_wifi`  Turns on/off guest wifi
@@ -107,7 +107,9 @@ The following script can be used to easily add a reconnect button to your UI. If
 fritz_box_reconnect:
   alias: "Reconnect FRITZ!Box"
   sequence:
-  - service: fritzbox_tools.reconnect_[model]
+  - service: fritzbox_tools.reconnect
+    data:
+        host: 192.168.178.1
 ```
 
 **Automation: Reconnect / get new IP every night**
@@ -119,7 +121,9 @@ automation:
     platform: time
     at: '05:00:00'
   action:
-    - service: fritzbox_tools.reconnect_[model]
+    - service: fritzbox_tools.reconnect
+      data:
+        host: 192.168.178.1
 ```
 
 **Automation: Phone notification with wifi credentials when guest wifi is created**

--- a/README.md
+++ b/README.md
@@ -87,14 +87,15 @@ If the switch is toggled on, the devices assigned to the specific profile have i
 
 #### Exposed entities
 
-- `service.reconnect`  Reconnect to your ISP
-- `service.reboot`  Reboot your FRITZ!Box
-- `switch.fritzbox_wifi`  Turns on/off wifi
-- `switch.fritzbox_wifi_5ghz`  Turns on/off wifi (5GHz)
-- `switch.fritzbox_guest_wifi`  Turns on/off guest wifi
-- `binary_sensor.fritzbox_connectivity`  online/offline depending on your internet connection
-- `switch.fritzbox_portforward_[description of your forward]` for each of your port forwards for your HA device
-- `switch.fritzbox_profile_[name of your profile]` for each profile you have set
+- `service.reconnect_[model]`  Reconnect to your ISP
+- `service.reboot_[model]`  Reboot your FRITZ!Box
+- `switch.fritzbox_[model_wifi]`  Turns on/off wifi
+- `switch.fritzbox_[model_wifi_5ghz]`  Turns on/off wifi (5GHz)
+- `switch.fritzbox_[model]_guest_wifi`  Turns on/off guest wifi
+- `binary_sensor.fritzbox_[model]_connectivity`  online/offline depending on your internet connection
+- `switch.fritzbox_[model]_portforward_[description of your forward]` for each of your port forwards for your HA device
+- `switch.fritzbox_[model]_deflection_[if of your deflection]` for each deflection you have set.
+- `switch.fritzbox_[model]_profile_[name of your profile]` for each profile you have set
 
 
 ## Example Automations and Scripts

--- a/README.md
+++ b/README.md
@@ -37,17 +37,18 @@ Go to the `Integrations pane` on your Home Assistant instance.
 **Using `configuration.yml` (legacy):**
 ```yaml
 fritzbox_tools:
-  host: "192.168.178.1"  # required
-  username: "home-assistant"  # required (create one at `System > FRITZ!Box Benutzer` on your router)
-  password: "yourfritzboxpassword"  # required
-  profiles: # Optional. Needed if you want to control the profiles of your network devices.
-    - "Gesperrt"
-    - "Gast"
-    - "Kinder Smartphones"
-  use_wifi: True # Optional, default True: if False no wifi switches will be exposed
-  use_port: True  # Optional, default True: if False no port switches will be exposed
-  use_profiles: True  # Optional, default True: if False no device switches will be exposed, redundant if devices is not specified
-  use_deflections: True # Optional, default True: if False no call deflection switches will be exposed
+  devices:
+    - host: "192.168.178.1"  # required
+      username: "home-assistant"  # required (create one at `System > FRITZ!Box Benutzer` on your router)
+      password: "yourfritzboxpassword"  # required
+      profiles: # Optional. Needed if you want to control the profiles of your network devices.
+        - "Gesperrt"
+        - "Gast"
+        - "Kinder Smartphones"
+      use_wifi: True # Optional, default True: if False no wifi switches will be exposed
+      use_port: True  # Optional, default True: if False no port switches will be exposed
+      use_profiles: True  # Optional, default True: if False no device switches will be exposed, redundant if devices is not specified
+      use_deflections: True # Optional, default True: if False no call deflection switches will be exposed
 ```
 
 ### Prepare your FRITZ!Box

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -45,12 +45,14 @@ DATA_FRITZ_TOOLS_INSTANCE = "fritzbox_tools_instance"
 
 _LOGGER = logging.getLogger(__name__)
 
+
 def ensure_unique_hosts(value):
     """Validate that all configs have a unique host."""
     vol.Schema(vol.Unique("duplicate host entries found"))(
         [socket.gethostbyname(entry[CONF_HOST]) for entry in value]
     )
     return value
+
 
 CONFIG_SCHEMA = vol.Schema(
     vol.All(
@@ -159,26 +161,27 @@ class FritzBoxTools(object):
     Attention: The initialization of the class performs sync I/O. If you're calling this from within Home Assistant,
     wrap it in await self.hass.async_add_executor_job(lambda: FritzBoxTools(...))
     """
+
     def __init__(
-        self,
-        password,
-        username = DEFAULT_USERNAME,
-        host = DEFAULT_HOST,
-        port=DEFAULT_PORT,
-        profile_list = DEFAULT_PROFILES,
-        use_port = DEFAULT_USE_PORT,
-        use_deflections = DEFAULT_USE_DEFLECTIONS,
-        use_wifi = DEFAULT_USE_WIFI,
-        use_profiles = DEFAULT_USE_PROFILES,
+            self,
+            password,
+            username=DEFAULT_USERNAME,
+            host=DEFAULT_HOST,
+            port=DEFAULT_PORT,
+            profile_list=DEFAULT_PROFILES,
+            use_port=DEFAULT_USE_PORT,
+            use_deflections=DEFAULT_USE_DEFLECTIONS,
+            use_wifi=DEFAULT_USE_WIFI,
+            use_profiles=DEFAULT_USE_PROFILES,
     ):
         # pylint: disable=import-error
         from fritzconnection import FritzConnection
         from fritzconnection.lib.fritzstatus import FritzStatus
         from fritzprofiles import FritzProfileSwitch
         from fritzconnection.core.exceptions import FritzConnectionException
-        
+
         # general timeout for all requests to the router. Some calls need quite some time.
-        
+
         try:
             self.connection = FritzConnection(
                 address=host, port=port, user=username, password=password, timeout=60.0
@@ -188,7 +191,7 @@ class FritzBoxTools(object):
                     "http://" + host, username, password, profile
                 ) for profile in profile_list}
             else:
-                self.profile_switch={}
+                self.profile_switch = {}
 
             self.fritzstatus = FritzStatus(fc=self.connection)
             self._unique_id = self.connection.call_action("DeviceInfo:1", "GetInfo")[
@@ -206,9 +209,8 @@ class FritzBoxTools(object):
         except AttributeError:
             self.success = False
             self.error = "profile_not_found"
-            
-            
-        self.ha_ip = get_local_ip()    
+
+        self.ha_ip = get_local_ip()
         self.profile_list = profile_list
 
         self.username = username
@@ -220,7 +222,7 @@ class FritzBoxTools(object):
         self.use_port = use_port
         self.use_deflections = use_deflections
         self.use_profiles = use_profiles
-        
+
     def service_reconnect_fritzbox(self, call) -> None:
         _LOGGER.info("Reconnecting the fritzbox.")
         self.connection.reconnect()
@@ -231,14 +233,14 @@ class FritzBoxTools(object):
 
     def is_ok(self):
         return self.success, self.error
-        
+
     @property
     def unique_id(self):
         return self._unique_id
-    
+
     @property
     def fritzbox_model(self):
-        return self._device_info["model"].replace("FRITZ!Box ","")
+        return self._device_info["model"].replace("FRITZ!Box ", "")
 
     @property
     def device_info(self):

--- a/custom_components/fritzbox_tools/binary_sensor.py
+++ b/custom_components/fritzbox_tools/binary_sensor.py
@@ -22,7 +22,7 @@ async def async_setup_entry(
     hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
 ) -> None:
     _LOGGER.debug("Setting up sensors")
-    fritzbox_tools = hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE]
+    fritzbox_tools = hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE][entry.entry_id]
 
     async_add_entities([FritzBoxConnectivitySensor(fritzbox_tools)], True)
     return True
@@ -30,12 +30,12 @@ async def async_setup_entry(
 
 class FritzBoxConnectivitySensor(BinarySensorEntity):
     name = "FRITZ!Box Connectivity"
-    entity_id = ENTITY_ID_FORMAT.format("fritzbox_connectivity")
     icon = "mdi:router-wireless"
     device_class = "connectivity"
 
     def __init__(self, fritzbox_tools):
         self.fritzbox_tools = fritzbox_tools
+        self.entity_id = ENTITY_ID_FORMAT.format(f"fritzbox_{self.fritzbox_tools.fritzbox_model}_connectivity")
         self._is_on = True  # We assume the fritzbox to be online initially
         self._is_available = (
             True  # set to False if an error happend during toggling the switch

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -36,7 +36,6 @@ from homeassistant.const import (
 
 from . import FritzBoxTools, CONFIG_SCHEMA
 
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -50,15 +49,15 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
     def __init__(self):
         """Initialize FRITZ!Box Tools flow."""
         pass
-        
+
     async def async_step_ssdp(self, discovery_info):
         """Handle a flow initialized by discovery."""
         ssdp_location = urlparse(discovery_info[ATTR_SSDP_LOCATION])
         self._host = ssdp_location.hostname
         self._port = ssdp_location.port
-        self._name = discovery_info.get(ATTR_UPNP_FRIENDLY_NAME) or host
+        self._name = discovery_info.get(ATTR_UPNP_FRIENDLY_NAME)
         self.context[CONF_HOST] = self._host
-        
+
         for progress in self._async_in_progress():
             if progress.get("context", {}).get(CONF_HOST) == self._host:
                 return self.async_abort(reason="already_in_progress")
@@ -68,7 +67,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             if entry.data[CONF_HOST] == self._host:
                 return self.async_abort(reason="already_configured")
 
-        self.context["title_placeholders"] = {"name": self._name.replace("FRITZ!Box ","")}
+        self.context["title_placeholders"] = {"name": self._name.replace("FRITZ!Box ", "")}
         return await self._show_setup_form_confirm()
 
     async def async_step_confirm(self, user_input=None):
@@ -98,8 +97,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             return await self._show_setup_form_confirm(errors)
 
         return await self._show_setup_form_options(errors)
-        
-    
+
     async def _show_setup_form_init(self, errors=None):
         """Show the setup form to the user."""
         return self.async_show_form(
@@ -114,7 +112,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             ),
             errors=errors or {},
         )
-    
+
     async def _show_setup_form_confirm(self, errors=None):
         """Show the setup form to the user."""
         return self.async_show_form(
@@ -179,15 +177,15 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             password=password,
             profile_list=[]
         ))
-        
+
         success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
         self._name = self.fritz_tools.device_info["model"]
-        
+
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if entry.data[CONF_HOST] == host:
                 success = False
                 error = "already_configured"
-        
+
         if not success:
             errors["base"] = error
             return await self._show_setup_form_init(errors)
@@ -195,9 +193,9 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         return await self._show_setup_form_options(errors)
 
     async def async_step_setup_options(self, user_input=None):
-        self._use_port = user_input.get(CONF_USE_PORT,DEFAULT_USE_PORT)
-        self._use_deflections = user_input.get(CONF_USE_DEFLECTIONS,DEFAULT_USE_DEFLECTIONS)
-        self._use_wifi = user_input.get(CONF_USE_WIFI,DEFAULT_USE_WIFI)
+        self._use_port = user_input.get(CONF_USE_PORT, DEFAULT_USE_PORT)
+        self._use_deflections = user_input.get(CONF_USE_DEFLECTIONS, DEFAULT_USE_DEFLECTIONS)
+        self._use_wifi = user_input.get(CONF_USE_WIFI, DEFAULT_USE_WIFI)
         self._use_profiles = user_input.get(CONF_USE_PROFILES, DEFAULT_USE_PROFILES)
 
         if self._use_profiles:
@@ -220,12 +218,11 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
                 },
             )
 
-
     async def async_step_setup_profiles(self, user_input=None):
-        profiles = user_input.get(CONF_PROFILES,DEFAULT_PROFILES)
+        profiles = user_input.get(CONF_PROFILES, DEFAULT_PROFILES)
         if isinstance(profiles, str):
             profiles = profiles.replace(', ', ',').split(',')
-        
+
         self.fritz_tools = await self.hass.async_add_executor_job(lambda: FritzBoxTools(
             host=self.fritz_tools.host,
             port=self.fritz_tools.port,
@@ -234,7 +231,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             profile_list=profiles,
         ))
         success, error = await self.hass.async_add_executor_job(self.fritz_tools.is_ok)
-        
+
         errors = {}
         if not success:
             errors["base"] = error
@@ -255,7 +252,6 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             },
         )
 
-
     async def async_step_import(self, import_config):
         """Import a FRITZ!Box Tools as a config entry.
 
@@ -269,16 +265,15 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         self.import_schema = CONFIG_SCHEMA
 
         errors = {}
-        
+
         host = import_config.get(CONF_HOST, DEFAULT_HOST)
         port = import_config.get(CONF_PORT, DEFAULT_PORT)
         username = import_config.get(CONF_USERNAME)
         password = import_config.get(CONF_PASSWORD)
-        profiles = import_config.get(CONF_PROFILES,DEFAULT_PROFILES)
+        profiles = import_config.get(CONF_PROFILES, DEFAULT_PROFILES)
 
         if isinstance(profiles, str):
             profiles = profiles.replace(" ", "").split(",")
-            
 
         fritz_tools = await self.hass.async_add_executor_job(lambda: FritzBoxTools(
             host=host,
@@ -289,13 +284,13 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         ))
         success, error = await self.hass.async_add_executor_job(fritz_tools.is_ok)
         self._name = fritz_tools.device_info["model"]
-        
+
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if entry.data[CONF_HOST] == host:
                 return self.async_abort()
-        
+
         if not success:
-            _LOGGER.error('Import of config failed. Check your fritzbox credentials',error)
+            _LOGGER.error('Import of config failed. Check your fritzbox credentials', error)
 
         return self.async_create_entry(
             title=self._name,

--- a/custom_components/fritzbox_tools/services.yaml
+++ b/custom_components/fritzbox_tools/services.yaml
@@ -1,5 +1,13 @@
 reconnect:
   description: Reconnects your FRITZ!Box internet connection.
+  fields:
+    host:
+      description: IP Adress of the FRITZ!Box (must be configured in HA)
+      example: 192.168.178.1
 
 reboot:
   description: Reboots your FRITZ!Box.
+  fields:
+    host:
+      description: IP Adress of the FRITZ!Box (must be configured in HA)
+      example: 192.168.178.1

--- a/custom_components/fritzbox_tools/strings.json
+++ b/custom_components/fritzbox_tools/strings.json
@@ -44,10 +44,6 @@
             "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box. Check your profiles in the FRITZ!Box at Internet/Filters/Access Profiles.",
             "already_in_progress": "FRITZ!Box configuration is already in progress.",
             "already_configured": "This AVM FRITZ!Box is already configured."
-        },
-        "abort": {
-            "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",
-            "existing_instance_updated": "Updated existing configuration."
         }
     }
 }

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -24,7 +24,7 @@ SCAN_INTERVAL = timedelta(seconds=30)  # update of profile switch takes too long
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
+        hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
 ) -> None:
     _LOGGER.debug("Setting up switches")
     fritzbox_tools = hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE][entry.entry_id]
@@ -33,7 +33,8 @@ async def async_setup_entry(
         deflections_response = fritzbox_tools.connection.call_action("X_AVM-DE_OnTel:1", "GetNumberOfDeflections")
         _LOGGER.debug(deflections_response)
         _LOGGER.debug(fritzbox_tools.connection.services)
-        if "X_AVM-DE_OnTel1" in fritzbox_tools.connection.services and deflections_response["NewNumberOfDeflections"] != 0:
+        if "X_AVM-DE_OnTel1" in fritzbox_tools.connection.services and deflections_response[
+            "NewNumberOfDeflections"] != 0:
             try:
                 _LOGGER.debug("Setting up deflection switches")
                 deflections = xmltodict.parse(
@@ -121,6 +122,7 @@ async def async_setup_entry(
                 async_add_entities,
                 [FritzBoxWifiSwitch(fritzbox_tools, net, networks[net])],
             )
+
     if fritzbox_tools.use_wifi:
         hass.async_add_executor_job(_create_wifi_switches)
     if fritzbox_tools.use_port:
@@ -192,11 +194,12 @@ class FritzBoxPortSwitch(SwitchEntity):
         from fritzconnection.core.exceptions import FritzConnectionException
 
         try:
-            self.port_mapping = await self.hass.async_add_executor_job(lambda: self.fritzbox_tools.connection.call_action(
-                self.connection_type,
-                "GetGenericPortMappingEntry",
-                NewPortMappingIndex=self._idx,
-            ))
+            self.port_mapping = await self.hass.async_add_executor_job(
+                lambda: self.fritzbox_tools.connection.call_action(
+                    self.connection_type,
+                    "GetGenericPortMappingEntry",
+                    NewPortMappingIndex=self._idx,
+                ))
             _LOGGER.debug(self.port_mapping)
             self._is_on = self.port_mapping["NewEnabled"] is True
             self._is_available = True
@@ -220,11 +223,10 @@ class FritzBoxPortSwitch(SwitchEntity):
 
     async def async_update(self):
         if (
-            self._last_toggle_timestamp is not None
-            and time.time() < self._last_toggle_timestamp + self._update_grace_period
+                self._last_toggle_timestamp is not None
+                and time.time() < self._last_toggle_timestamp + self._update_grace_period
         ):
             # We skip update for 5 seconds after toggling the switch
-            # This is because the router needs some time to change the guest wifi state
             _LOGGER.debug(
                 "Not updating switch state, because last toggle happend < 5 seconds ago"
             )
@@ -347,11 +349,11 @@ class FritzBoxDeflectionSwitch(SwitchEntity):
             self._is_available = True
 
             self._attributes["Type"] = self.dict_of_deflection["Type"]
-            self._attributes["Number"] =  self.dict_of_deflection["Number"]
-            self._attributes["DeflectionToNumber"] =  self.dict_of_deflection["DeflectionToNumber"]
-            self._attributes["Mode"] =  self.dict_of_deflection["Mode"]
-            self._attributes["Outgoing"] =  self.dict_of_deflection["Outgoing"]
-            self._attributes["PhonebookID"] =  self.dict_of_deflection["PhonebookID"]
+            self._attributes["Number"] = self.dict_of_deflection["Number"]
+            self._attributes["DeflectionToNumber"] = self.dict_of_deflection["DeflectionToNumber"]
+            self._attributes["Mode"] = self.dict_of_deflection["Mode"]
+            self._attributes["Outgoing"] = self.dict_of_deflection["Outgoing"]
+            self._attributes["PhonebookID"] = self.dict_of_deflection["PhonebookID"]
 
         except FritzConnectionException:
             _LOGGER.error(
@@ -365,11 +367,10 @@ class FritzBoxDeflectionSwitch(SwitchEntity):
 
     async def async_update(self):
         if (
-            self._last_toggle_timestamp is not None
-            and time.time() < self._last_toggle_timestamp + self._update_grace_period
+                self._last_toggle_timestamp is not None
+                and time.time() < self._last_toggle_timestamp + self._update_grace_period
         ):
             # We skip update for 5 seconds after toggling the switch
-            # This is because the router needs some time to change the guest wifi state
             _LOGGER.debug(
                 "Not updating switch state, because last toggle happend < 5 seconds ago"
             )
@@ -407,7 +408,7 @@ class FritzBoxDeflectionSwitch(SwitchEntity):
         new_state = '1' if turn_on else '0'
         try:
             self.hass.async_add_executor_job(lambda: self.fritzbox_tools.connection.call_action(
-                "X_AVM-DE_OnTel:1","SetDeflectionEnable", NewDeflectionId=self.id, NewEnable=new_state
+                "X_AVM-DE_OnTel:1", "SetDeflectionEnable", NewDeflectionId=self.id, NewEnable=new_state
             ))
         except FritzSecurityError:
             _LOGGER.error(
@@ -442,8 +443,8 @@ class FritzBoxProfileSwitch(SwitchEntity):
         id = f"fritzbox_{self.fritzbox_tools.fritzbox_model}_profile_{self.profile}"
         self.entity_id = ENTITY_ID_FORMAT.format(slugify(id))
 
-        self._is_available = True 
-        self._is_on = None 
+        self._is_available = True
+        self._is_on = None
 
         super().__init__()
 
@@ -494,7 +495,7 @@ class FritzBoxProfileSwitch(SwitchEntity):
         else:
             self._is_on = False
             _LOGGER.error(
-                "An error occurred while turning on fritzbox_tools Guest wifi switch."
+                "An error occurred while turning on fritzbox_tools profile switch."
             )
 
     async def async_turn_off(self, **kwargs) -> None:
@@ -505,7 +506,7 @@ class FritzBoxProfileSwitch(SwitchEntity):
         else:
             self._is_on = True
             _LOGGER.error(
-                "An error occurred while turning off fritzbox_tools Guest wifi switch."
+                "An error occurred while turning off fritzbox_tools profile switch."
             )
 
     async def _async_handle_profile_switch_on_off(self, turn_on: bool) -> bool:
@@ -569,7 +570,7 @@ class FritzBoxWifiSwitch(SwitchEntity):
             wifi_info = await self.hass.async_add_executor_job(lambda: self._fritzbox_tools.connection.call_action(
                 f"WLANConfiguration:{self._network_num}", "GetInfo"
             ))
-            _LOGGER.debug("Guest WiFi GetInfo:")
+            _LOGGER.debug("WiFi GetInfo:")
             _LOGGER.debug(wifi_info)
             self._is_on = True if wifi_info["NewStatus"] == "Up" else False
             self._is_available = True
@@ -586,8 +587,8 @@ class FritzBoxWifiSwitch(SwitchEntity):
 
     async def async_update(self):
         if (
-            self._last_toggle_timestamp is not None
-            and time.time() < self._last_toggle_timestamp + self._update_grace_period
+                self._last_toggle_timestamp is not None
+                and time.time() < self._last_toggle_timestamp + self._update_grace_period
         ):
             # We skip update for 5 seconds after toggling the switch
             # This is because the router needs some time to change the wifi state

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -536,7 +536,7 @@ class FritzBoxWifiSwitch(SwitchEntity):
         id = network_name.lower().replace(' ', '_').replace('(', '').replace(')', '')
         self.entity_id = ENTITY_ID_FORMAT.format(f"fritzbox_{self._fritzbox_tools.fritzbox_model}_{id}")
         self._name = f"FRITZ!Box {network_name}"
-        self._is_on = False
+        self._is_on = None
         self._last_toggle_timestamp = None
         self._is_available = (
             True  # set to False if an error happend during toggling the switch
@@ -572,7 +572,7 @@ class FritzBoxWifiSwitch(SwitchEntity):
             ))
             _LOGGER.debug("WiFi GetInfo:")
             _LOGGER.debug(wifi_info)
-            self._is_on = True if wifi_info["NewStatus"] == "Up" else False
+            self._is_on = wifi_info["NewEnable"] is True
             self._is_available = True
         except FritzConnectionException:
             _LOGGER.error(

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -27,7 +27,7 @@ async def async_setup_entry(
     hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
 ) -> None:
     _LOGGER.debug("Setting up switches")
-    fritzbox_tools = hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE]
+    fritzbox_tools = hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE][entry.entry_id]
 
     def _create_deflection_switches():
         deflections_response = fritzbox_tools.connection.call_action("X_AVM-DE_OnTel:1", "GetNumberOfDeflections")
@@ -151,7 +151,7 @@ class FritzBoxPortSwitch(SwitchEntity):
 
         description = port_mapping["NewPortMappingDescription"]
         self._name = f"Port forward {description}"
-        id = f"fritzbox_portforward_{slugify(description)}"
+        id = f"fritzbox_{self.fritzbox_tools.fritzbox_model}_portforward_{slugify(description)}"
         self.entity_id = ENTITY_ID_FORMAT.format(id)
 
         self._attributes = defaultdict(str)
@@ -291,7 +291,7 @@ class FritzBoxDeflectionSwitch(SwitchEntity):
         self.dict_of_deflection = dict_of_deflection
         self.id = int(self.dict_of_deflection["DeflectionId"])
         self._name = f"Deflection {self.id}"
-        id = f"fritzbox_deflection_{self.id}"
+        id = f"fritzbox_{self.fritzbox_tools.fritzbox_model}_deflection_{self.id}"
         self.entity_id = ENTITY_ID_FORMAT.format(id)
 
         self._attributes = defaultdict(str)
@@ -439,7 +439,7 @@ class FritzBoxProfileSwitch(SwitchEntity):
         self.profile_switch = self.fritzbox_tools.profile_switch[self.profile]
 
         self._name = f"Access profile {self.profile}"
-        id = f"fritzbox_profile_{self.profile}"
+        id = f"fritzbox_{self.fritzbox_tools.fritzbox_model}_profile_{self.profile}"
         self.entity_id = ENTITY_ID_FORMAT.format(slugify(id))
 
         self._is_available = True 
@@ -533,7 +533,7 @@ class FritzBoxWifiSwitch(SwitchEntity):
         self._fritzbox_tools = fritzbox_tools
         self._network_num = network_num
         id = network_name.lower().replace(' ', '_').replace('(', '').replace(')', '')
-        self.entity_id = ENTITY_ID_FORMAT.format(f"fritzbox_{id}")
+        self.entity_id = ENTITY_ID_FORMAT.format(f"fritzbox_{self._fritzbox_tools.fritzbox_model}_{id}")
         self._name = f"FRITZ!Box {network_name}"
         self._is_on = False
         self._last_toggle_timestamp = None

--- a/custom_components/fritzbox_tools/translations/de.json
+++ b/custom_components/fritzbox_tools/translations/de.json
@@ -44,10 +44,6 @@
             "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box. Check your profiles in the FRITZ!Box at Internet/Filters/Access Profiles.",
             "already_in_progress": "FRITZ!Box configuration is already in progress.",
             "already_configured": "This AVM FRITZ!Box is already configured."
-        },
-        "abort": {
-            "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",
-            "existing_instance_updated": "Updated existing configuration."
         }
     }
 }

--- a/custom_components/fritzbox_tools/translations/en.json
+++ b/custom_components/fritzbox_tools/translations/en.json
@@ -44,10 +44,6 @@
             "profile_not_found": "The format of the spcified profile(s) is wrong or profile not found in FRITZ!Box. Check your profiles in the FRITZ!Box at Internet/Filters/Access Profiles.",
             "already_in_progress": "FRITZ!Box configuration is already in progress.",
             "already_configured": "This AVM FRITZ!Box is already configured."
-        },
-        "abort": {
-            "single_instance_allowed": "Only a single configuration of FRITZ!Box Tools is allowed.",
-            "existing_instance_updated": "Updated existing configuration."
         }
     }
 }


### PR DESCRIPTION
**BREAKING CHANGES:**

*Entity-id naming:*

| Current        | New           | 
| ------------- |:-------------:| 
`switch.fritzbox_wifi`                               | `switch.fritzbox_{model}_wifi` |
`switch.fritzbox_wifi_5ghz`                    | `switch.fritzbox_{model}_wifi_5ghz`  |
`binary_sensor.fritzbox_connectivity`  | `binary_sensor.fritzbox_{model}_wifi_connectivity`  |
`switch.fritzbox_portforward_X`.         | `switch.fritzbox_{model}_portforward_X`  |
`switch.fritzbox_profile_X`.                   | `switch.fritzbox_{model}_profile_X`  |
`switch.fritzbox_deflection_X`               | `switch.fritzbox_{model}_deflection_X`  |

*Services:*
Supply additional data:
```yaml
  - service: fritzbox_tools.reconnect
    data:
      host: 192.168.178.1
  - service: fritzbox_tools.reboot
    data:
      host: 192.168.178.1
```

{host} = IP Adress of configured FRITZ!Box (e.g. 192.168.178.1)
{model} = FRITZ!Box model (e.g. 6490)



**I tested (as appropriate):**
- [x] Yaml Mode
- [x] Discovery Mode
- [x] UI Mode

Closes issue #72 

- [x] renamings in readme?! How @mammuth?