### PR TITLE
add uuid from discovery info to to entry

### DIFF
--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -106,7 +106,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
 
         return self._show_setup_form_options(errors)
 
-    async def _show_setup_form_init(self, errors=None):
+    def _show_setup_form_init(self, errors=None):
         """Show the setup form to the user."""
         return self.async_show_form(
             step_id="start_config",
@@ -168,7 +168,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
 
     async def async_step_start_config(self, user_input=None):
         if user_input is None:
-            return await self._show_setup_form_init()
+            return self._show_setup_form_init()
 
         errors = {}
 

--- a/custom_components/fritzbox_tools/strings.json
+++ b/custom_components/fritzbox_tools/strings.json
@@ -38,6 +38,10 @@
                 }
               }  
         },
+        "abort": {
+          "already_in_progress": "FRITZ!Box configuration is already in progress.",
+          "already_configured": "This AVM FRITZ!Box is already configured."
+        },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
             "connection_error_profiles": "Profile switches only work if login with FRITZ!Box user name and password is enabled in the FRITZ!Box. This can be changed in the FRITZ!Box at System/FRITZ!Box Users/Login to the Home Network.",

--- a/custom_components/fritzbox_tools/translations/de.json
+++ b/custom_components/fritzbox_tools/translations/de.json
@@ -38,6 +38,10 @@
                 }
               }  
         },
+        "abort": {
+          "already_in_progress": "FRITZ!Box configuration is already in progress.",
+          "already_configured": "This AVM FRITZ!Box is already configured."
+        },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
             "connection_error_profiles": "Profile switches only work if login with FRITZ!Box user name and password is enabled in the FRITZ!Box. This can be changed in the FRITZ!Box at System/FRITZ!Box Users/Login to the Home Network.",

--- a/custom_components/fritzbox_tools/translations/en.json
+++ b/custom_components/fritzbox_tools/translations/en.json
@@ -38,6 +38,10 @@
                 }
               }  
         },
+        "abort": {
+          "already_in_progress": "FRITZ!Box configuration is already in progress.",
+          "already_configured": "This AVM FRITZ!Box is already configured."
+        },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",
             "connection_error_profiles": "Profile switches only work if login with FRITZ!Box user name and password is enabled in the FRITZ!Box. This can be changed in the FRITZ!Box at System/FRITZ!Box Users/Login to the Home Network.",


### PR DESCRIPTION
- uuid was needed for hassfest and ignore of component
- removed unneeded async keywords

Closes issue #122 
