### PR TITLE
Removed microsecond precision from last_reconnect sensor

### DIFF
--- a/custom_components/fritzbox_tools/binary_sensor.py
+++ b/custom_components/fritzbox_tools/binary_sensor.py
@@ -74,7 +74,7 @@ class FritzBoxConnectivitySensor(BinarySensorEntity):
             status = self.fritzbox_tools.fritzstatus
             uptime_seconds = await self.hass.async_add_executor_job(lambda: getattr(status, "uptime"))
             last_reconnect = datetime.datetime.now() - datetime.timedelta(seconds=uptime_seconds)
-            self._attributes["last_reconnect"] = last_reconnect.replace(microsecond=1).isoformat()
+            self._attributes["last_reconnect"] = last_reconnect.replace(microsecond=0).isoformat()
 
             for attr in [
                 "modelname",


### PR DESCRIPTION

I tested (as appropriate):
- [ ] Get/Set port switch
- [ ] Get/Set 2.4 Ghz wifi
- [ ] Get/Set 5 Ghz wifi
- [ ] Get/Set guest wifi switch
- [ ] Get/Set call deflections
- [x] Connectivity sensor
- [ ] Yaml Mode

Reference issue #115 