### PR TITLE
Update config_flow.py

### DIFF
--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -294,7 +294,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             if entry.data[CONF_HOST] == host:
-                return self.async_abort()
+                return self.async_abort(reason='ready')
 
         if not success:
             _LOGGER.error('Import of config failed. Check your fritzbox credentials', error)


### PR DESCRIPTION
add parameter "reason" to async_abort since it is not optional



I tested (as appropriate):
- [x] restart add_on