### PR TITLE
Add 'reauth' config flow

### DIFF
--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -37,16 +37,15 @@ from .const import (
     DEFAULT_USE_PROFILES,
     DEFAULT_USE_DEFLECTIONS,
     DEFAULT_USE_PORT,
+    ERROR_CONNECTION_ERROR,
+    ERROR_CONNECTION_ERROR_PROFILES,
+    ERROR_PROFILE_NOT_FOUND,
 )
 
 REQUIREMENTS = ["fritzconnection==1.2.0", "fritz-switch-profiles==1.0.0", "xmltodict==0.12.0"]
 
 DATA_FRITZ_TOOLS_INSTANCE = "fritzbox_tools_instance"
 ATTR_HOST = "host"
-
-ERROR_CONNECTION_ERROR = "connection_error"
-ERROR_CONNECTION_ERROR_PROFILES = "connection_error_profiles"
-ERROR_PROFILE_NOT_FOUND = "profile_not_found"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -131,13 +131,13 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     ))
 
     success, error = await hass.async_add_executor_job(fritz_tools.is_ok)
-    if not success and error is ERROR_CONNECTION_ERROR:       
+    if not success and error is ERROR_CONNECTION_ERROR:
         _LOGGER.error("Unable to setup FRITZ!Box Tools component.")
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
                 context={"source": SOURCE_REAUTH},
-                data=entry.data,
+                data=entry,
             )
         )
         return False
@@ -155,6 +155,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         )
 
     return True
+
 
 def setup_hass_services(hass):
     """Home Assistant services."""

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -336,7 +336,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_USERNAME, default=user_input.get(CONF_USERNAME)): str,
-                    vol.Required(CONF_PASSWORD, default=user_input.get(CONF_PASSWORD)): str,
+                    vol.Required(CONF_PASSWORD): str,
                 }
             ),
             description_placeholders={"host": self._host},
@@ -347,9 +347,8 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
         """Dialog that informs the user that reauth is required."""
         if user_input is None:
             return self._show_setup_form_reauth_confirm(
-                user_input = {
-                    CONF_USERNAME: self._username,
-                    CONF_PASSWORD: self._password
+                user_input={
+                    CONF_USERNAME: self._username
                 }
             )
 

--- a/custom_components/fritzbox_tools/config_flow.py
+++ b/custom_components/fritzbox_tools/config_flow.py
@@ -314,18 +314,18 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             },
         )
 
-    async def async_step_reauth(self, config_data=None):
+    async def async_step_reauth(self, entry):
         """Handle flow upon an API authentication error."""
-        if config_data is not None:
-            self._host = config_data.get(CONF_HOST, DEFAULT_HOST)
-            self._port = config_data.get(CONF_PORT, DEFAULT_PORT)
-            self._username = config_data.get(CONF_USERNAME)
-            self._password = config_data.get(CONF_PASSWORD)
-            self._profiles = config_data.get(CONF_PROFILES, DEFAULT_PROFILES)
-            self._use_port = config_data.get(CONF_USE_PORT, DEFAULT_USE_PORT)
-            self._use_deflections = config_data.get(CONF_USE_DEFLECTIONS, DEFAULT_USE_DEFLECTIONS)
-            self._use_wifi = config_data.get(CONF_USE_WIFI, DEFAULT_USE_WIFI)
-            self._use_profiles = config_data.get(CONF_USE_PROFILES, DEFAULT_USE_PROFILES)
+        self._entry = entry
+        self._host = entry.data.get(CONF_HOST, DEFAULT_HOST)
+        self._port = entry.data.get(CONF_PORT, DEFAULT_PORT)
+        self._username = entry.data.get(CONF_USERNAME)
+        self._password = entry.data.get(CONF_PASSWORD)
+        self._profiles = entry.data.get(CONF_PROFILES, DEFAULT_PROFILES)
+        self._use_port = entry.data.get(CONF_USE_PORT, DEFAULT_USE_PORT)
+        self._use_deflections = entry.data.get(CONF_USE_DEFLECTIONS, DEFAULT_USE_DEFLECTIONS)
+        self._use_wifi = entry.data.get(CONF_USE_WIFI, DEFAULT_USE_WIFI)
+        self._use_profiles = entry.data.get(CONF_USE_PROFILES, DEFAULT_USE_PROFILES)
 
         return await self.async_step_reauth_confirm()
 
@@ -373,21 +373,19 @@ class FritzBoxToolsFlowHandler(ConfigFlow):
             errors["base"] = error
             return self._show_setup_form_reauth_confirm(user_input=user_input, errors=errors)
 
-        for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.data[CONF_HOST] == host:
-                self.hass.config_entries.async_update_entry(
-                    entry, 
-                    data={
-                        CONF_HOST: host,
-                        CONF_PASSWORD: password,
-                        CONF_PORT: port,
-                        CONF_USERNAME: username,
-                        CONF_PROFILES: self._profiles,
-                        CONF_USE_WIFI: self._use_wifi,
-                        CONF_USE_DEFLECTIONS: self._use_deflections,
-                        CONF_USE_PORT: self._use_port,
-                        CONF_USE_PROFILES: self._use_profiles,
-                    }
-                )
-                await self.hass.config_entries.async_reload(entry.entry_id)
-                return self.async_abort(reason="reauth_successful")
+        self.hass.config_entries.async_update_entry(
+            self._entry,
+            data={
+                CONF_HOST: host,
+                CONF_PASSWORD: password,
+                CONF_PORT: port,
+                CONF_USERNAME: username,
+                CONF_PROFILES: self._profiles,
+                CONF_USE_WIFI: self._use_wifi,
+                CONF_USE_DEFLECTIONS: self._use_deflections,
+                CONF_USE_PORT: self._use_port,
+                CONF_USE_PROFILES: self._use_profiles,
+            },
+        )
+        await self.hass.config_entries.async_reload(self._entry.entry_id)
+        return self.async_abort(reason="reauth_successful")

--- a/custom_components/fritzbox_tools/const.py
+++ b/custom_components/fritzbox_tools/const.py
@@ -23,3 +23,7 @@ DEFAULT_PROFILES = []
 
 SERVICE_RECONNECT = "reconnect"
 SERVICE_REBOOT = "reboot"
+
+ERROR_CONNECTION_ERROR = "connection_error"
+ERROR_CONNECTION_ERROR_PROFILES = "connection_error_profiles"
+ERROR_PROFILE_NOT_FOUND = "profile_not_found"

--- a/custom_components/fritzbox_tools/strings.json
+++ b/custom_components/fritzbox_tools/strings.json
@@ -36,11 +36,20 @@
                     "username": "Username",
                     "password": "Password"
                 }
-              }  
+              },  
+              "reauth_confirm": {
+                  "title": "Updating FRITZ!Box Tools - credentials",
+                  "description": "Update FRITZ!Box Tools credentials for: {host}.\n\nFRITZ!Box Tools is unable to log in to your FRITZ!Box.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                  "data": {
+                      "username": "Username",
+                      "password": "Password"
+                  }
+                }
         },
         "abort": {
           "already_in_progress": "FRITZ!Box configuration is already in progress.",
-          "already_configured": "This AVM FRITZ!Box is already configured."
+          "already_configured": "This AVM FRITZ!Box is already configured.",
+          "reauth_successful": "FRITZ!Box configuration successfully updated."
         },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",

--- a/custom_components/fritzbox_tools/translations/de.json
+++ b/custom_components/fritzbox_tools/translations/de.json
@@ -36,11 +36,20 @@
                     "username": "Username",
                     "password": "Password"
                 }
-              }  
+              },  
+              "reauth_confirm": {
+                  "title": "Updating FRITZ!Box Tools - credentials",
+                  "description": "Update FRITZ!Box Tools credentials for: {host}.\n\nFRITZ!Box Tools is unable to log in to your FRITZ!Box.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                  "data": {
+                      "username": "Username",
+                      "password": "Password"
+                  }
+                }
         },
         "abort": {
           "already_in_progress": "FRITZ!Box configuration is already in progress.",
-          "already_configured": "This AVM FRITZ!Box is already configured."
+          "already_configured": "This AVM FRITZ!Box is already configured.",
+          "reauth_successful": "FRITZ!Box configuration successfully updated."
         },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",

--- a/custom_components/fritzbox_tools/translations/en.json
+++ b/custom_components/fritzbox_tools/translations/en.json
@@ -36,11 +36,20 @@
                     "username": "Username",
                     "password": "Password"
                 }
-              }  
+              },  
+              "reauth_confirm": {
+                  "title": "Updating FRITZ!Box Tools - credentials",
+                  "description": "Update FRITZ!Box Tools credentials for: {host}.\n\nFRITZ!Box Tools is unable to log in to your FRITZ!Box.\nDocumentation: https://github.com/mammuth/ha-fritzbox-tools",
+                  "data": {
+                      "username": "Username",
+                      "password": "Password"
+                  }
+                }
         },
         "abort": {
           "already_in_progress": "FRITZ!Box configuration is already in progress.",
-          "already_configured": "This AVM FRITZ!Box is already configured."
+          "already_configured": "This AVM FRITZ!Box is already configured.",
+          "reauth_successful": "FRITZ!Box configuration successfully updated."
         },
         "error": {
             "connection_error": "Failed to connect to FRITZ!Box. Check your username and password.",


### PR DESCRIPTION
With the recent security disclosure, users are advised to change their credentials.

After changing the credentials on the FRITZ!Box, this custom component didn't provide any means to change the entered credentials through the new Integration UI.

The Config Entry Flow supports [Reauthentication](https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#reauthentication). This PR implements this flow, to update the credentials for a FRITZ!Box in case the setup fails due to an `FritzConnectionException` error.

Screens how it appears on the integration page:
![image](https://user-images.githubusercontent.com/4631548/105633947-d2680780-5e5b-11eb-9934-43a0974e92d0.png)

(Credentials are prefilled with the config data)
![image](https://user-images.githubusercontent.com/4631548/105633973-ec094f00-5e5b-11eb-8419-021eaa7aa972.png)

Success dialog unfortunately shows 'Aborted'. This is due to using an abort result, to resolve the flow. However this is from the official docs. Providing an appropriate flow resolve is up to the Home Assistant Core devs. 
![image](https://user-images.githubusercontent.com/4631548/105634032-55895d80-5e5c-11eb-8ec1-a40b74ab5c98.png)



I tested (as appropriate):
- [ ] Get/Set port switch
- [ ] Get/Set 2.4 Ghz wifi
- [ ] Get/Set 5 Ghz wifi
- [ ] Get/Set guest wifi switch
- [ ] Get/Set call deflections
- [ ] Connectivity sensor
- [ ] Yaml Mode
