### PR TITLE
Bump fritzconnection to 1.4.0

### DIFF
--- a/custom_components/fritzbox_tools/manifest.json
+++ b/custom_components/fritzbox_tools/manifest.json
@@ -4,7 +4,7 @@
     "documentation": "https://github.com/mammuth/ha-fritzbox-tools/blob/master/README.md",
     "codeowners": ["@mammuth"],
     "dependencies": [],
-    "requirements": ["fritzconnection==1.2.0", "fritzprofiles==0.5.2", "xmltodict==0.12.0"],
+    "requirements": ["fritzconnection==1.4.0", "fritzprofiles==0.5.2", "xmltodict==0.12.0"],
     "config_flow": true,
     "ssdp": [
       {


### PR DESCRIPTION
This PR bumps the dependency to be aligned to what is already used on HA native side: 
https://github.com/home-assistant/core/blob/dev/homeassistant/components/fritz/manifest.json
