### PR TITLE
Use host as key for hass data

### DIFF
--- a/custom_components/fritzbox_tools/__init__.py
+++ b/custom_components/fritzbox_tools/__init__.py
@@ -90,7 +90,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         return False
 
     hass.data.setdefault(DOMAIN, {DATA_FRITZ_TOOLS_INSTANCE: {}, CONF_DEVICES: set()})
-    hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE][entry.entry_id] = fritz_tools
+    hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE][host] = fritz_tools
 
     setup_hass_services(hass)
 
@@ -144,7 +144,7 @@ def setup_hass_services(hass):
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigType) -> bool:
     """Unload FRITZ!Box Tools config entry."""
-    hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE].pop(entry.entry_id)
+    hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE].pop(entry.data.get(CONF_HOST))
     hass.services.async_remove(DOMAIN, SERVICE_RECONNECT)
     hass.services.async_remove(DOMAIN, SERVICE_REBOOT)
 

--- a/custom_components/fritzbox_tools/binary_sensor.py
+++ b/custom_components/fritzbox_tools/binary_sensor.py
@@ -16,6 +16,7 @@ except ImportError:
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.const import CONF_HOST
 
 from .const import DATA_FRITZ_TOOLS_INSTANCE, DOMAIN
 
@@ -29,7 +30,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up entry."""
     _LOGGER.debug("Setting up sensors")
-    fritzbox_tools = hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE][entry.entry_id]
+    fritzbox_tools = hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE][entry.data.get(CONF_HOST)]
 
     if "WANIPConn1" in fritzbox_tools.connection.services:
         """ We do not support repeaters at the moment """

--- a/custom_components/fritzbox_tools/switch.py
+++ b/custom_components/fritzbox_tools/switch.py
@@ -18,6 +18,7 @@ except ImportError:
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import slugify
+from homeassistant.const import CONF_HOST
 
 from .const import DATA_FRITZ_TOOLS_INSTANCE, DOMAIN
 
@@ -31,7 +32,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up entry."""
     _LOGGER.debug("Setting up switches")
-    fritzbox_tools = hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE][entry.entry_id]
+    fritzbox_tools = hass.data[DOMAIN][DATA_FRITZ_TOOLS_INSTANCE][entry.data.get(CONF_HOST)]
 
     def _create_deflection_switches():
         if "X_AVM-DE_OnTel1" in fritzbox_tools.connection.services:


### PR DESCRIPTION
This should fix issue with reboot and reconnect services not working.
I do not use port forwarding or call deflections so did not test those but the changes should not affect them as far as I know


I tested (as appropriate):
- [ ] Get/Set port switch
- [x] Get/Set 2.4 Ghz wifi
- [x] Get/Set 5 Ghz wifi
- [x] Get/Set guest wifi switch
- [ ] Get/Set call deflections
- [x] Connectivity sensor
- [ ] Yaml Mode

Closes issue #161 